### PR TITLE
Fixed issue with product detail view and missing bank transfer fields

### DIFF
--- a/admin_config.php
+++ b/admin_config.php
@@ -454,10 +454,6 @@ class vstore_order_ui extends e_admin_ui
 			'paypal_rest_secret'    => array('title'=>"Paypal Secret", 'type'=>'text', 'tab'=>1, 'data'=>'str', 'help'=>'', 'writeParms'=>array('size'=>'xxlarge')),
 		//	'paypal_signature'      => array('title'=>"Paypal Signature", 'type'=>'text', 'tab'=>0, 'data'=>'str', 'help'=>'', 'writeParms'=>array('size'=>'xxlarge')),
 
-			'bank_transfer_active'    => array('title'=>"Bank Transfer", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>''),
-			'bank_transfer_details'    => array('title'=>"Bank Transfer", 'type'=>'textarea', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Bank Account Details"), 'help'=>''),
-
-
 			'coinbase_active'     => array('title'=>"Coinbase Payments", 'type'=>'boolean', 'tab'=>2, 'data'=>'int', 'help'=>''),
 			'coinbase_account'    => array('title'=>"Coinbase Account ID", 'type'=>'text', 'tab'=>2, 'data'=>'str', 'help'=>'', 'writeParms'=>array('size'=>'xxlarge')),
 			'coinbase_api_key'    => array('title'=>"Coinbase API key", 'type'=>'text', 'tab'=>2, 'data'=>'str', 'help'=>'', 'writeParms'=>array('size'=>'xxlarge')),
@@ -470,6 +466,10 @@ class vstore_order_ui extends e_admin_ui
 
 			'skrill_active'         => array('title'=>"Skrill Payments", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>''),
 			'skrill_email'          => array('title'=>"Skrill Email", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'help'=>'', 'writeParms'=>array('size'=>'xxlarge')),
+
+			'bank_transfer_active'    => array('title'=>"Bank Transfer", 'type'=>'boolean', 'tab'=>5, 'data'=>'int', 'help'=>''),
+			'bank_transfer_details'    => array('title'=>"Bank Transfer", 'type'=>'textarea', 'tab'=>5, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Bank Account Details"), 'help'=>''),
+
 		);
 
 

--- a/admin_config.php
+++ b/admin_config.php
@@ -417,22 +417,23 @@ class vstore_order_ui extends e_admin_ui
 
 
 		protected $fields 		= array (
-		 'checkboxes'           =>   array ( 'title' => '', 'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
-		  'order_id'            =>   array ( 'title' => LAN_ID, 'data' => 'int', 'width' => '5%', 'help' => '', 'readonly'=>true, 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		  'order_status'          => array('title'=>'Status', 'type'=>'dropdown', 'data'=>'str', 'inline'=>true, 'filter'=>true, 'batch'=>true,'width'=>'5%'),
-		  'order_date'          =>   array ( 'title' => LAN_DATESTAMP, 'type' => 'datestamp', 'data' => 'str',  'readonly'=>true, 'width' => 'auto', 'filter' => true, 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+			'checkboxes'           	=> array ( 'title' => '', 'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
+			'order_id'            	=> array ( 'title' => LAN_ID, 'data' => 'int', 'width' => '5%', 'help' => '', 'readonly'=>true, 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+			'order_status'          => array ( 'title' => 'Status', 'type'=>'dropdown', 'data'=>'str', 'inline'=>true, 'filter'=>true, 'batch'=>true,'width'=>'5%'),
+			'order_date'          	=> array ( 'title' => LAN_DATESTAMP, 'type' => 'datestamp', 'data' => 'str',  'readonly'=>true, 'width' => 'auto', 'filter' => true, 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 
-		  'order_session'       =>   array ( 'title' => 'Session', 'type' => 'text', 'tab'=>1, 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		  'order_ship_to'      =>  array('title'=>'Ship to', 'type'=>'method', 'data'=>false, 'width'=>'20%'),
-		  'order_items'     =>   array ( 'title' => "Items", 'type' => 'method', 'data' => false, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'right', 'thclass' => 'right',  ),
-		 'order_e107_user'     =>   array ( 'title' => LAN_AUTHOR, 'type' => 'method', 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		 'order_pay_gateway'       =>   array ( 'title' => 'Gateway', 'type' => 'text', 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		 'order_pay_status'        =>   array ( 'title' => 'Pay Status', 'type' => 'text',  'data' => 'str',  'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		 'order_pay_transid'       =>   array ( 'title' => 'TransID', 'type' => 'text', 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		  'order_pay_amount' =>   array ( 'title' => 'Total', 'type' => 'method', 'data' => 'int', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		  'order_pay_shipping' =>   array ( 'title' => 'Shipping', 'type' => 'number', 'data' => 'int', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		  'order_pay_rawdata' =>   array ( 'title' => 'Rawdata', 'type' => 'method', 'tab'=>1, 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		  'options' =>   array ( 'title' => LAN_OPTIONS, 'type' => null, 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => '1',  ),
+			'order_ship_to'      	=> array ( 'title' => 'Ship to', 'type'=>'method', 'data'=>false, 'width'=>'20%'),
+			'order_items'     		=> array ( 'title' => "Items", 'type' => 'method', 'data' => false, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'right', 'thclass' => 'right',  ),
+			'order_e107_user'     	=> array ( 'title' => LAN_AUTHOR, 'type' => 'method', 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+			'order_pay_gateway'     => array ( 'title' => 'Gateway', 'type' => 'text', 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+			'order_pay_status'      => array ( 'title' => 'Pay Status', 'type' => 'text',  'data' => 'str',  'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+			'order_pay_transid'     => array ( 'title' => 'TransID', 'type' => 'text', 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+			'order_pay_amount' 		=> array ( 'title' => 'Total', 'type' => 'method', 'data' => 'int', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+			'order_pay_shipping' 	=> array ( 'title' => 'Shipping', 'type' => 'number', 'data' => 'int', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+			'order_ship_notes'      => array ( 'title' => 'Notes', 'type'=>'method', 'tab'=>1, 'data'=>false, 'width'=>'20%'),
+			'order_session'       	=> array ( 'title' => 'Session', 'type' => 'text', 'tab'=>1, 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+			'order_pay_rawdata' 	=> array ( 'title' => 'Rawdata', 'type' => 'method', 'tab'=>1, 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+			'options' 				=> array ( 'title' => LAN_OPTIONS, 'type' => null, 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => '1',  ),
 		);
 
 		protected $fieldpref = array('order_id','order_ship_to', 'order_status', 'order_date', 'order_items', 'order_pay_transid','order_pay_amount','order_pay_status');
@@ -657,6 +658,17 @@ class vstore_order_form_ui extends e_admin_form_ui
 
 	}
 
+	function order_ship_notes($curVal, $mode)
+	{
+		switch($mode)
+		{
+			case 'read':
+			case 'write':
+				$notes = $this->getController()->getFieldVar('order_ship_notes');
+				return $notes;
+				break;
+		}
+	}
 
 
 	function order_pay_amount($curVal,$mode)
@@ -776,7 +788,7 @@ Secret Key 	secret_key 	Default : null
 Region 	region
  */
 		// optional
-		protected $preftabs = array(LAN_GENERAL, "Emails", "How to Order", "Admin Area");
+		protected $preftabs = array(LAN_GENERAL, "Emails", "How to Order", "Admin Area", "Additional checkout fields");
 
 
 		protected $prefs = array(
@@ -795,6 +807,31 @@ Region 	region
 
 			'admin_items_perpage'	    => array('title'=> 'Products per page', 'tab'=>3, 'type'=>'number', 'help'=>''),
 			'admin_categories_perpage'	=> array('title'=> 'Categories per page', 'tab'=>3, 'type'=>'number', 'help'=>''),
+			'admin_confirm_order'		=> array('title'=> 'Confirm order', 'tab'=>3, 'type'=>'bool', 'help'=>'If ON, the customer has to confirm his order after selecting the payment method on the checkout page!'),
+
+			'add_field1_active'    		=> array('title'=>"Field 1 active", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>'Field 1 will be rendered as text box'),
+			'add_field1_caption'    	=> array('title'=>"Field 1 caption", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 1 caption"), 'help'=>''),
+			'add_field1_placeholder'   	=> array('title'=>"Field 1 placeholder", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 1 placeholder"), 'help'=>''),
+			'add_field1_required'  		=> array('title'=>"Field 1 required", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>''),
+			'add_field1_separator' 		=> array('title'=>"", 'type'=>'', 'tab'=>4, 'data'=>'int', 'help'=>''),
+
+			'add_field2_active'    		=> array('title'=>"Field 2 active", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>'Field 2 will be rendered as text box'),
+			'add_field2_caption'    	=> array('title'=>"Field 2 caption", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 2 caption"), 'help'=>''),
+			'add_field2_placeholder'   	=> array('title'=>"Field 2 placeholder", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 2 placeholder"), 'help'=>''),
+			'add_field2_required'  		=> array('title'=>"Field 2 required", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>''),
+			'add_field2_separator' 		=> array('title'=>"", 'type'=>'', 'tab'=>4, 'data'=>'int', 'help'=>''),
+
+			'add_field3_active'    		=> array('title'=>"Field 3 active", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>'Field 3 will be rendered as checkbox'),
+			'add_field3_caption'    	=> array('title'=>"Field 3 caption", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 3 caption"), 'help'=>''),
+			'add_field3_help'    		=> array('title'=>"Field 3 help text", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 3 help text"), 'help'=>''),
+			'add_field3_required'  		=> array('title'=>"Field 3 required", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>''),
+			'add_field3_separator' 		=> array('title'=>"", 'type'=>'', 'tab'=>4, 'data'=>'int', 'help'=>''),
+
+			'add_field4_active'    		=> array('title'=>"Field 4 active", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>'Field 4 will be rendered as checkbox'),
+			'add_field4_caption'    	=> array('title'=>"Field 4 caption", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 4 caption"), 'help'=>''),
+			'add_field4_help'    		=> array('title'=>"Field 4 help text", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 4 help text"), 'help'=>''),
+			'add_field4_required'  		=> array('title'=>"Field 4 required", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>''),
+			'add_field4_separator' 		=> array('title'=>"", 'type'=>'', 'tab'=>4, 'data'=>'int', 'help'=>''),
 
 		);
 

--- a/e_url.php
+++ b/e_url.php
@@ -63,6 +63,13 @@ class vstore_url // plugin-folder + '_url'
 
 		);
 
+		$config['product'] = array(
+			'regex'			=> '^{alias}/([^\/]*)/([\d]*)/(.*)',
+			'sef'			=> '{alias}/{cat_sef}/{item_id}/{item_sef}',
+			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?item=$2',
+
+		);
+
 		$config['subcategory'] = array(
 			'regex'			=> '^{alias}\/([^\/]*)\/([^\/\?]*)\/$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?catsef=$2',
@@ -75,15 +82,6 @@ class vstore_url // plugin-folder + '_url'
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?catsef=$1&',
 			'sef'			=> '{alias}/{cat_sef}/'
 		);
-
-		$config['product'] = array(
-			'regex'			=> '^{alias}/([^\/]*)/([\d]*)/(.*)',
-			'sef'			=> '{alias}/{cat_sef}/{item_id}/{item_sef}',
-			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?item=$2',
-
-		);
-		
-
 		
 		return $config;
 	}

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -1982,7 +1982,7 @@ class vstore
 		
 		    <div class="row">
 		        <div class="col-sm-12 col-md-12">
-		            <table class="table table-hover">
+		            <table class="table table-hover cart">
 		                <thead>
 		                    <tr>
 		                        <th>Product</th>

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -679,6 +679,26 @@ class vstore
 			$this->captionBase = $pref['caption'][e_LANGUAGE];
 		}
 
+		if (vartrue($pref['add_field1_active'], false))
+		{
+			static::$shippingFields[] = 'add_field1';
+		}
+
+		if (vartrue($pref['add_field2_active'], false))
+		{
+			static::$shippingFields[] = 'add_field2';
+		}
+
+		if (vartrue($pref['add_field3_active'], false))
+		{
+			static::$shippingFields[] = 'add_field3';
+		}
+
+		if (vartrue($pref['add_field4_active'], false))
+		{
+			static::$shippingFields[] = 'add_field4';
+		}
+
 
 
 		if(!empty($pref['caption_categories']) && !empty($pref['caption_categories'][e_LANGUAGE]))
@@ -926,6 +946,64 @@ class vstore
 			    		';
 
 
+		/**
+		 * Additional checkout fields
+		 * Start
+		 */
+		$pref = e107::pref('vstore');
+		$addFieldActive = 0;
+		for ($i=1; $i<5; $i++) 
+		{
+			// Check if additional fields are enabled
+			if (vartrue($pref['add_field'.$i.'_active'], false))
+			{
+				$addFieldActive++;
+			}
+		}
+
+		if ($addFieldActive > 0)
+		{
+			// If any additional fields are enabled
+			// add active fields to form
+			$text .= '<br/><div class="row">';
+			for ($i=1; $i<5; $i++) 
+			{
+				if (vartrue($pref['add_field'.$i.'_active'], false))
+				{
+					if ($i >= 1 && $i <= 2)
+					{
+						// Textboxes
+						$field = $frm->text('add_field'.$i, $this->post['add_field'.$i], 100, array('placeholder'=>varset($pref['add_field'.$i.'_placeholder'], ''), 'required'=>vartrue($pref['add_field'.$i.'_required'], true)));
+					}
+					elseif ($i >= 3 && $i <= 4)
+					{
+						// Checkboxes
+						$field = '<div class="form-control-static">'.$frm->checkbox('add_field'.$i, 1, $this->post['add_field'.$i], array('required'=>vartrue($pref['add_field'.$i.'_required'], true)));
+						if (vartrue($pref['add_field'.$i.'_help']))
+						{
+							$field .= ' <span class="text-muted">&nbsp;'.$pref['add_field'.$i.'_help'].'</span>';
+						}
+						$field .= '</div>';
+					}
+
+					// Bootstrap wrapper for control
+					$text .= '
+						<div class="'.($addFieldActive == 1 ? 'col-md-12' : 'col-xs-6 col-sm-6 col-md-6').'">
+							<div class="form-group">
+								<label for="add_field'.$i.'">'.varset($pref['add_field'.$i.'_caption'], 'Additional field '.$i).'</label>
+								'.$field.'
+							</div>
+						</div>
+					';			
+				}
+			}
+			$text .= '</div>';
+		}
+		/**
+		 * Additional checkout fields
+		 * End
+		 */
+
 		if(!USER)
 		{
 			$text .= '<div class="row">
@@ -1163,6 +1241,25 @@ class vstore
 			$text .= "</div>";
 			$text .= e107::getForm()->close();
 
+			if (vartrue(e107::pref('vstore', 'admin_confirm_order')))
+			{
+				// If the user has to confirm the order
+				$text .= '
+				<script type="text/javascript">
+				$(function(){
+					$("#gateway-select").submit(function(e){
+						if(!confirm("By clicking on OK you confirm that you order the content of the shopping cart for the shown cost!"))
+						{
+							e.preventDefault();
+							return false;
+						}
+						return true;
+					});
+				});
+				</script>
+				';
+			}
+
 			return $text;
 		}
 
@@ -1281,7 +1378,7 @@ class vstore
 			$transID = null;
 			$transData = null;
 			$this->saveTransaction($transID, $transData, $items);
-		//	$this->resetCart();
+			$this->resetCart();
 
 			if(!empty($message))
 			{
@@ -2016,12 +2113,37 @@ class vstore
 
 	private function setShippingData($data=array())
 	{
-
+		$pref = e107::pref('vstore');
 		$fields = self::getShippingFields();
-
+		$order_ship_add_fields = array();
 		foreach($fields as $fld)
 		{
-			$_SESSION['vstore']['shipping']['order_ship_'.$fld] = $data[$fld];
+			if (substr($fld, 0, strlen('add_field')) == 'add_field')
+			{
+				$fieldid = intval(substr($fld, strlen('add_field')));
+				$caption = strip_tags(varset($pref[$fld.'_caption'], 'Field '.$fieldid));
+				if ($fieldid <= 2)
+				{
+					$order_ship_add_fields[] = $caption . ': ' . $data[$fld];
+				}
+				else
+				{
+					$order_ship_add_fields[] = $caption . ': ' . ($data[$fld] ? 'Checked' : 'Unchecked');
+				}
+			}
+			else
+			{
+				$_SESSION['vstore']['shipping']['order_ship_'.$fld] = trim(strip_tags($data[$fld]));
+			}
+		}
+		if (varset($order_ship_add_fields))
+		{
+			//$_SESSION['vstore']['shipping']['order_ship_add_fields'] = implode("<br/>\n", $order_ship_add_fields);
+			if ($_SESSION['vstore']['shipping']['order_ship_notes'] != '')
+			{
+				$_SESSION['vstore']['shipping']['order_ship_notes'] .= "<br/>\n<br/>\n";
+			}
+			$_SESSION['vstore']['shipping']['order_ship_notes'] .= implode("<br/>\n", $order_ship_add_fields);
 		}
 
 

--- a/vstore.css
+++ b/vstore.css
@@ -24,3 +24,5 @@
 .vstore-category-list .thumbnail .caption   { min-height:80px }
 
 .vstore-zoom::after                         { content: ''; display: block; width: 33px; height: 33px; position: absolute; top: 0; right: 0; background: url(https://raw.github.com/jackmoore/zoom/master/icon.png); }
+
+.cart h3, .cart h5                          { color: black; }

--- a/vstore_sql.php
+++ b/vstore_sql.php
@@ -36,7 +36,7 @@ CREATE TABLE vstore_orders (
   `order_ship_state` varchar(100) DEFAULT NULL,
   `order_ship_zip` varchar(20) DEFAULT NULL,
   `order_ship_country` varchar(100) DEFAULT NULL,
-  `order_ship_notes` varchar(255) DEFAULT NULL,
+  `order_ship_notes` text NOT NULL,
   `order_pay_gateway` varchar(50) DEFAULT NULL,
   `order_pay_status` varchar(250) DEFAULT NULL,
   `order_pay_transid` varchar(250) DEFAULT NULL,


### PR DESCRIPTION
**Update e_url.php**: moved $config['product'] up in the file, because it was never reached (because of $config['subcategory'])

**Update admin_config.php**: Moved "bank_transfer_active" & "bank_transfer_details" down in the list and changed the "tab" setting for both settings to 5 (Bank transfer)
Bank Transfer tab was empty before...

**Implemented additional optional fields to the checkout page.**: Added in total 4 optional fields to the checkout page (2 textboxes, 2 checkboxes), which will be saved to the "shipping notes" field (without overwriting it). They can be used to force the user to e.g. confirm the terms of service, request specific information (e.g. account name), etc.
Added also an optional confirmation message to make sure the customer is aware the he is really ordering now and to give him still the option to cancel this process.

**Fix for white colored h3, h5 on cart in some themes**: Some themes use different colors for h3 and h5 tags (e.g. white), which make it hard to read them on the shopping cart.
