### PR TITLE
Fixed some typos and implemented the new additional field prefs

### DIFF
--- a/admin_config.php
+++ b/admin_config.php
@@ -812,30 +812,6 @@ Region 	region
 
 			'additional_fields'         => array('title'=>'Additional Fields', 'tab'=>4, 'type'=>'method'),
 
-		/*	'add_field1_active'    		=> array('title'=>"Field 1 active", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>'Field 1 will be rendered as text box'),
-			'add_field1_caption'    	=> array('title'=>"Field 1 caption", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 1 caption"), 'help'=>''),
-			'add_field1_placeholder'   	=> array('title'=>"Field 1 placeholder", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 1 placeholder"), 'help'=>''),
-			'add_field1_required'  		=> array('title'=>"Field 1 required", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>''),
-			'add_field1_separator' 		=> array('title'=>"", 'type'=>'', 'tab'=>4, 'data'=>'int', 'help'=>''),
-
-			'add_field2_active'    		=> array('title'=>"Field 2 active", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>'Field 2 will be rendered as text box'),
-			'add_field2_caption'    	=> array('title'=>"Field 2 caption", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 2 caption"), 'help'=>''),
-			'add_field2_placeholder'   	=> array('title'=>"Field 2 placeholder", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 2 placeholder"), 'help'=>''),
-			'add_field2_required'  		=> array('title'=>"Field 2 required", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>''),
-			'add_field2_separator' 		=> array('title'=>"", 'type'=>'', 'tab'=>4, 'data'=>'int', 'help'=>''),
-
-			'add_field3_active'    		=> array('title'=>"Field 3 active", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>'Field 3 will be rendered as checkbox'),
-			'add_field3_caption'    	=> array('title'=>"Field 3 caption", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 3 caption"), 'help'=>''),
-			'add_field3_help'    		=> array('title'=>"Field 3 help text", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 3 help text"), 'help'=>''),
-			'add_field3_required'  		=> array('title'=>"Field 3 required", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>''),
-			'add_field3_separator' 		=> array('title'=>"", 'type'=>'', 'tab'=>4, 'data'=>'int', 'help'=>''),
-
-			'add_field4_active'    		=> array('title'=>"Field 4 active", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>'Field 4 will be rendered as checkbox'),
-			'add_field4_caption'    	=> array('title'=>"Field 4 caption", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 4 caption"), 'help'=>''),
-			'add_field4_help'    		=> array('title'=>"Field 4 help text", 'type'=>'text', 'tab'=>4, 'data'=>'str', 'writeParms'=>array('placeholder'=>"Field 4 help text"), 'help'=>''),
-			'add_field4_required'  		=> array('title'=>"Field 4 required", 'type'=>'boolean', 'tab'=>4, 'data'=>'int', 'help'=>''),
-			'add_field4_separator' 		=> array('title'=>"", 'type'=>'', 'tab'=>4, 'data'=>'int', 'help'=>''),*/
-
 		);
 
 
@@ -1363,8 +1339,8 @@ class vstore_items_ui extends e_admin_ui
 	
 		protected $fields 		= array (  
 		  'checkboxes' 			=>   array ( 'title' => '', 'type' => null, 'data' => null, 	'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
-		  'item_preview'       =>   array( 'title' => LAN_PREVIEW, 'type'=>'method', 'data'=>false, 'width'=>'5%', 'forced'=>1),
-		   'item_id' 			=>   array ( 'title' => LAN_ID, 			'type'=>'text', 'data' => 'int', 	'width' => '5%', 'help' => '', 'readParms'=>'link=sef&target=blank', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+		  'item_preview'        =>   array( 'title' => LAN_PREVIEW, 'type'=>'method', 'data'=>false, 'width'=>'5%', 'forced'=>1),
+		  'item_id' 			=>   array ( 'title' => LAN_ID, 			'type'=>'text', 'data' => 'int', 	'width' => '5%', 'help' => '', 'readParms'=>'link=sef&target=blank', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 		  'item_code' 			=>   array ( 'title' => 'Code', 			'type' => 'text', 'inline'=>true,	'data' => 'str', 'width' => '2%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'center', 'thclass' => 'center',  ),
 		  'item_name'			=>   array ( 'title' => LAN_TITLE, 			'type' => 'text', 	'data' => 'str', 'width' => 'auto', 'inline' => true, 'help' => '', 'readParms' => '', 'writeParms' => array('size'=>'xxlarge'), 'class' => 'left', 'thclass' => 'left',  ),
 		  'item_desc' 			=>   array ( 'title' => 'Description', 		'type' => 'textarea', 	'data' => 'str', 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => array('size'=>'xxlarge','maxlength'=>250), 'class' => 'center', 'thclass' => 'center',  ),
@@ -1378,9 +1354,8 @@ class vstore_items_ui extends e_admin_ui
 		  'item_related' 		=>   array ( 'title' => 'Related', 			'type' => 'method', 'tab'=>2, 'data' => 'array', 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => 'video=1', 'class' => 'center', 'thclass' => 'center',  ),
 	 
 		  'item_order' 			=>   array ( 'title' => LAN_ORDER, 			'type' => 'hidden', 'data' => 'int', 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		  'item_inventory' 		=>   array ( 'title' => 'Inventory', 		'type' => 'method', 'data' => 'int', 'width' => 'auto', 'inline'=>true, 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'right item-inventory', 'thclass' => 'right',  ),
+		  'item_inventory' 		=>   array ( 'title' => 'Inventory', 		'type' => 'method', 'data' => 'int', 'width' => 'auto', 'inline'=>true, 'help' => 'Enter -1 if this item is always available', 'readParms' => '', 'writeParms' => '', 'class' => 'right item-inventory', 'thclass' => 'right',  ),
 		  'item_vars' 	        =>   array ( 'title' => 'Product Variations', 	'type' => 'comma', 'data' => 'str', 'width' => 'auto', 'inline'=>true, 'help' => '', 'readParms' => '', 'writeParms' => array(), 'class' => 'right item-inventory', 'thclass' => 'right',  ),
-
 
 
 		  'item_link' 			=>   array ( 'title' => 'External Link', 	'type' => 'text', 'tab'=>3, 'data' => 'str', 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'center', 'thclass' => 'center',  ),
@@ -1554,7 +1529,8 @@ class vstore_items_form_ui extends e_admin_form_ui
 			break;
 
 			case 'write': // Edit Page
-				return $frm->number('item_inventory',$curVal);
+				return $frm->text('item_inventory', $curVal, null, array('pattern' => '^-?\d+$')); // to allow also negative values (<0 = Item will not run out of stock)
+				//return $frm->number('item_inventory',$curVal);
 			break;
 
 			case 'filter':

--- a/admin_config.php
+++ b/admin_config.php
@@ -664,7 +664,7 @@ class vstore_order_form_ui extends e_admin_form_ui
 		{
 			case 'read':
 			case 'write':
-				$notes = $this->getController()->getFieldVar('order_ship_notes');
+				$notes = nl2br($this->getController()->getFieldVar('order_ship_notes'));
 				return $notes;
 				break;
 		}
@@ -884,19 +884,19 @@ class vstore_cart_form_ui extends e_admin_form_ui
 
 			$activeVal       = !empty($curVal[$i]['active']) ? $curVal[$i]['active'] : null;
 			$capVal          = !empty($curVal[$i]['caption'][e_LANGUAGE]) ? $curVal[$i]['caption'][e_LANGUAGE] : null;
-			$placeholderVal  = !empty($curVal[$i]['placeholder'][e_LANGUAGE]) ? $curVal[$i]['caption'][e_LANGUAGE] : null;
+			$placeholderVal  = !empty($curVal[$i]['placeholder'][e_LANGUAGE]) ? $curVal[$i]['placeholder'][e_LANGUAGE] : null;
 			$reqVal          = !empty($curVal[$i]['required']) ? $curVal[$i]['required'] : null;
-			$typeVal          = !empty($curVal[$i]['type']) ? $curVal[$i]['type'] : 'text';
+			$typeVal         = !empty($curVal[$i]['type']) ? $curVal[$i]['type'] : 'text';
 
 			$post = '<small class="input-group-addon"><i class="fa fa-language"><!-- --></i></small>';
 
 			$text .= "
 				<tr>
-					<td>".$this->flipswitch('additional_fields['.$i.'][active]', $activeVal, null, array('switch'=>'small'))."</td>
+					<td>".$this->flipswitch('additional_fields['.$i.'][active]', $activeVal, null, array('switch'=>'small', 'title' => LAN_ACTIVE))."</td>
 					<td><span class='input-group'>".$this->text('additional_fields['.$i.'][caption]['.e_LANGUAGE.']', $capVal, 30, array('placeholder'=>LAN_CAPTION, 'size'=>'block-level')).$post."</span></td>
 					<td><span class='input-group'>".$this->text('additional_fields['.$i.'][placeholder]['.e_LANGUAGE.']',$placeholderVal, 30, array('placeholder'=>"Placeholder", 'size'=>'block-level')).$post."</span></td>
 					<td>".$this->select('additional_fields['.$i.'][type]', $opts, $typeVal )."</td>
-					<td>".$this->flipswitch('additional_fields['.$i.'][required]', $reqVal)."</td>
+					<td>".$this->flipswitch('additional_fields['.$i.'][required]', $reqVal, null, array('switch'=>'small', 'title' => 'Required'))."</td>
 				</tr>
 			";
 

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -679,27 +679,13 @@ class vstore
 			$this->captionBase = $pref['caption'][e_LANGUAGE];
 		}
 
-		if (vartrue($pref['add_field1_active'], false))
+		foreach($pref['additional_fields'] as $k => $v)
 		{
-			static::$shippingFields[] = 'add_field1';
+			if (vartrue($v['active'], false))
+			{
+				static::$shippingFields[] = 'add_field'.$k;
+			}
 		}
-
-		if (vartrue($pref['add_field2_active'], false))
-		{
-			static::$shippingFields[] = 'add_field2';
-		}
-
-		if (vartrue($pref['add_field3_active'], false))
-		{
-			static::$shippingFields[] = 'add_field3';
-		}
-
-		if (vartrue($pref['add_field4_active'], false))
-		{
-			static::$shippingFields[] = 'add_field4';
-		}
-
-
 
 		if(!empty($pref['caption_categories']) && !empty($pref['caption_categories'][e_LANGUAGE]))
 		{
@@ -952,10 +938,10 @@ class vstore
 		 */
 		$pref = e107::pref('vstore');
 		$addFieldActive = 0;
-		for ($i=1; $i<5; $i++) 
+		foreach ($pref['additional_fields'] as $k => $v) 
 		{
 			// Check if additional fields are enabled
-			if (vartrue($pref['add_field'.$i.'_active'], false))
+			if (vartrue($v['active'], false))
 			{
 				$addFieldActive++;
 			}
@@ -966,22 +952,23 @@ class vstore
 			// If any additional fields are enabled
 			// add active fields to form
 			$text .= '<br/><div class="row">';
-			for ($i=1; $i<5; $i++) 
+			foreach ($pref['additional_fields'] as $k => $v) 
 			{
-				if (vartrue($pref['add_field'.$i.'_active'], false))
+				if (vartrue($v['active'], false))
 				{
-					if ($i >= 1 && $i <= 2)
+					$fieldname = 'add_field'.$k;
+					if ($v['type'] == 'text')
 					{
 						// Textboxes
-						$field = $frm->text('add_field'.$i, $this->post['add_field'.$i], 100, array('placeholder'=>varset($pref['add_field'.$i.'_placeholder'], ''), 'required'=>vartrue($pref['add_field'.$i.'_required'], true)));
+						$field = $frm->text($fieldname, $this->post[$fieldname], 100, array('placeholder'=>varset($v['placeholder'][e_LANGUAGE], ''), 'required'=>($v['required'] ? 1 : 0)));
 					}
-					elseif ($i >= 3 && $i <= 4)
+					elseif ($v['type'] == 'checkbox')
 					{
 						// Checkboxes
-						$field = '<div class="form-control-static">'.$frm->checkbox('add_field'.$i, 1, $this->post['add_field'.$i], array('required'=>vartrue($pref['add_field'.$i.'_required'], true)));
-						if (vartrue($pref['add_field'.$i.'_help']))
+						$field = '<div class="form-control">'.$frm->checkbox($fieldname, 1, $this->post[$fieldname], array('required'=>($v['required'] ? 1 : 0)));
+						if (vartrue($v['placeholder']))
 						{
-							$field .= ' <span class="text-muted">&nbsp;'.$pref['add_field'.$i.'_help'].'</span>';
+							$field .= ' <span class="text-muted">&nbsp;'.$v['placeholder'][e_LANGUAGE].'</span>';
 						}
 						$field .= '</div>';
 					}
@@ -990,7 +977,7 @@ class vstore
 					$text .= '
 						<div class="'.($addFieldActive == 1 ? 'col-md-12' : 'col-xs-6 col-sm-6 col-md-6').'">
 							<div class="form-group">
-								<label for="add_field'.$i.'">'.varset($pref['add_field'.$i.'_caption'], 'Additional field '.$i).'</label>
+								<label for="'.$fieldname.'">'.varset($v['caption'][e_LANGUAGE], 'Additional field '.$k).'</label>
 								'.$field.'
 							</div>
 						</div>
@@ -2121,14 +2108,14 @@ class vstore
 			if (substr($fld, 0, strlen('add_field')) == 'add_field')
 			{
 				$fieldid = intval(substr($fld, strlen('add_field')));
-				$caption = strip_tags(varset($pref[$fld.'_caption'], 'Field '.$fieldid));
-				if ($fieldid <= 2)
+				$caption = strip_tags(varset($pref['additional_fields'][$fieldid]['caption'][e_LANGUAGE], 'Field '.$fieldid));
+				if ($pref['additional_fields'][$fieldid]['type'] == 'text')
 				{
-					$order_ship_add_fields[] = $caption . ': ' . $data[$fld];
+					$order_ship_add_fields[] = $caption . ': ' . trim(strip_tags($data[$fld]));
 				}
-				else
+				elseif ($pref['additional_fields'][$fieldid]['type'] == 'checkbox')
 				{
-					$order_ship_add_fields[] = $caption . ': ' . ($data[$fld] ? 'Checked' : 'Unchecked');
+					$order_ship_add_fields[] = $caption . ': ' . (vartrue($data[$fld], false) ? 'Checked' : 'Unchecked');
 				}
 			}
 			else
@@ -2138,12 +2125,12 @@ class vstore
 		}
 		if (varset($order_ship_add_fields))
 		{
-			//$_SESSION['vstore']['shipping']['order_ship_add_fields'] = implode("<br/>\n", $order_ship_add_fields);
 			if ($_SESSION['vstore']['shipping']['order_ship_notes'] != '')
 			{
-				$_SESSION['vstore']['shipping']['order_ship_notes'] .= "<br/>\n<br/>\n";
+				$_SESSION['vstore']['shipping']['order_ship_notes'] .= "\n\n";
 			}
-			$_SESSION['vstore']['shipping']['order_ship_notes'] .= implode("<br/>\n", $order_ship_add_fields);
+			$_SESSION['vstore']['shipping']['order_ship_notes'] .= "Additional fields:\n";
+			$_SESSION['vstore']['shipping']['order_ship_notes'] .= implode("\n", $order_ship_add_fields);
 		}
 
 

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -1910,7 +1910,8 @@ class vstore
 			}
 		}
 		
-		if(!empty($data['cat_info']))
+		//if(!empty($data['cat_info']))
+		if (!empty(e107::pref('vstore', 'howtoorder')))
 		{
 			$tabData['howto']		= array('caption'=>'How to Order', 'text'=> $tmpl['item']['howto']);
 		}


### PR DESCRIPTION
**vstore.class.php**: Implemented new additional field prefs (incl. some small other changes around this issue) and fixed

**admin_config.php**: Fixed some typos and added a few missing properties

**item_inventory=-1**: Defines an item that is available without limit (e.g. downloads)

**inventory checks**: Checking cart on add/update if the item is still in stock and adjust the quantity accordingly

**How to order**: Fixed issue, where the how-to-order pref was only displayed, when the category "cat_info" (Details) field was not empty.