### PR TITLE
Assign userclass on purchase

### DIFF
--- a/admin_config.php
+++ b/admin_config.php
@@ -858,7 +858,8 @@ Region 	region
 
 			'sender_name'               => array('title'=> 'Sender Name', 'tab'=>1, 'type'=>'text', 'writeParms'=>array('placeholder'=>'Sales Department'), 'help'=>'Leave blank to use system default','multilan'=>false),
 			'sender_email'              => array('title'=> LAN_EMAIL, 'tab'=>1, 'type'=>'text', 'writeParms'=>array('placeholder'=>'orders@mysite.com'), 'help'=>'Leave blank to use system default', 'multilan'=>false),
-			'merchant_info'              => array('title'=> "Merchant Name/Address", 'tab'=>1, 'type'=>'textarea', 'writeParms'=>array('placeholder'=>'My Store Inc. etc.'), 'help'=>'Will be displayed on customer email.', 'multilan'=>false),
+			'merchant_info'             => array('title'=> "Merchant Name/Address", 'tab'=>1, 'type'=>'textarea', 'writeParms'=>array('placeholder'=>'My Store Inc. etc.'), 'help'=>'Will be displayed on customer email.', 'multilan'=>false),
+			'email_templates'           => array('title'=> "Email templates", 'tab'=>1, 'type'=>'method'), //, 'writeParms'=>array('placeholder'=>'My Store Inc. etc.'), 'help'=>'Will be displayed on customer email.', 'multilan'=>false),
 
 
 			'admin_items_perpage'	    => array('title'=> 'Products per page', 'tab'=>3, 'type'=>'number', 'help'=>''),
@@ -875,6 +876,29 @@ Region 	region
 		public function init()
 		{
 			$this->prefs['currency']['writeParms'] = array('USD'=>'US Dollars', 'EUR'=>'Euros', 'CAN'=>'Canadian Dollars');
+
+			$email_fields = array(
+				'{ORDER_REF}'			=> 'The order reference number',
+				'{ORDER_MERCHANT_INFO}'	=> 'Merchant name & adress',
+				'{ORDER_SHIP_FIRSTNAME}'=> 'The customers firstname',
+				'{ORDER_SHIP_LASTNAME}' => 'The customers lastname',
+				'{ORDER_SHIP_ADDRESS}'	=> 'The customers shipping to street',
+				'{ORDER_SHIP_CITY}'		=> 'The customers shipping to city',
+				'{ORDER_SHIP_STATE}'	=> 'The customers shipping to state',
+				'{ORDER_SHIP_ZIP}'		=> 'The customers shipping to zip code',
+				'{ORDER_SHIP_COUNTRY}'	=> 'The customers shipping to country',
+				'{ORDER_ITEMS}'			=> 'The ordered items',
+				'{ORDER_PAYMENT_INSTRUCTIONS}' => 'In case of payment method "bank transfer", the bank transfer details'
+			);
+	
+			foreach ($email_fields as $key => $value) {
+				$field_notes[] = sprintf('<div>%s</div><div class="col-sm-offset-1">%s</div>', $key, $value);
+			}
+	
+			$text = '<div>'.$this->prefs['email_templates']['title'].'<br/><br/>Available fields<br/>';
+			$text .= '<div class="small">'.implode("\n", $field_notes).'</div></div>';
+	
+			$this->prefs['email_templates']['title'] = $text;
 		}
 	
 	/*
@@ -893,6 +917,11 @@ Region 	region
 
 class vstore_cart_form_ui extends e_admin_form_ui
 {
+
+	public function init()
+	{
+
+	}
 
 	function additional_fields($curVal,$mode)
 	{
@@ -936,6 +965,36 @@ class vstore_cart_form_ui extends e_admin_form_ui
 		$text .= "</table>";
 
 		return $text;
+	}
+
+
+	function email_templates($curVal, $mode)
+	{
+		$frm = e107::getForm();		
+
+		$email_types = array(
+			'default' => 'Order confirmation', 
+			'completed' => 'Order completed'
+		);
+
+		e107::wysiwyg(true);
+		
+		$text = '';
+		foreach ($email_types as $type => $label) {
+
+			if (empty($curVal[$type]))
+			{
+				$curVal[$type] = e107::getTemplate('vstore', 'vstore_email', $type);
+			}
+
+			$text .= '<div><label><b>'.$label.'</b>';
+			$text .= $frm->textarea('email_templates['.$type.']', $curVal[$type], null, null, array('class' => 'e-wysiwyg'));		
+			$text .= '</label></div><br/>
+			';
+		}
+
+		return $text;
+		 		
 	}
 
 	function customer_userclass($curVal, $mode)

--- a/templates/vstore_email_template.php
+++ b/templates/vstore_email_template.php
@@ -18,7 +18,7 @@
 	 Hello {ORDER_SHIP_FIRSTNAME} {ORDER_SHIP_LASTNAME},<br />
 	 <br />
 	 Thank you for your purchase.<br />
-	 Your order reference number is: #{ORDER_REF})<br />
+	 Your order reference number is: #{ORDER_REF}<br />
 	 <br />
 	 <table class='table'>
 	 	<colgroup>	
@@ -45,6 +45,38 @@
 	 
 	 <hr />
 	 {ORDER_PAYMENT_INSTRUCTIONS}
+	 
+	 ";
+
+	 $VSTORE_EMAIL_TEMPLATE['completed'] = "
+		
+	 Hello {ORDER_SHIP_FIRSTNAME} {ORDER_SHIP_LASTNAME},<br />
+	 <br />
+	 your order #{ORDER_REF} has just been completed and will be shipped to you soon.<br />
+	 <br />
+	 <table class='table'>
+	 	<colgroup>	
+	 		<col style='width:50%' />
+	 		<col style='width:50%' />
+	 	</colgroup>
+	 	<tr>
+	 		<th>Merchant</th>
+	 		<th class='text-right'>Customer</th>
+	 	</tr>
+	 	<tr>
+	 		<td>{ORDER_MERCHANT_INFO}</td>
+	 		<td class='text-right'>
+	 			{ORDER_SHIP_FIRSTNAME} {ORDER_SHIP_LASTNAME}<br />
+	 			{ORDER_SHIP_ADDRESS}<br />
+	 			{ORDER_SHIP_CITY} &nbsp;{ORDER_SHIP_STATE} &nbsp;{ORDER_SHIP_ZIP}<br />
+	 			{ORDER_SHIP_COUNTRY}
+			</td>
+	 	</tr>
+	 </table>
+	 
+	 
+	 {ORDER_ITEMS}
+	 
 	 
 	 ";
 /*

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -1732,7 +1732,7 @@ class vstore
 				if ($sql->gen('SELECT item_inventory, item_name FROM #vstore_cart LEFT JOIN #vstore_items ON (cart_item = item_id) WHERE cart_id='.intval($id).' LIMIT 1'))
 				{
 					$inStock = $sql->fetch();
-					if ($qty > $inStock['item_inventory'])
+					if ($qty > $inStock['item_inventory'] && $inStock['item_inventory']>-1)
 					{
 						$qty = $inStock['item_inventory'];
 						e107::getMessage()->addWarning('Quantity of item "'.$inStock['item_name'].'" cart exceeds the number of items in stock!<br/>The quantity has been adjusted!', 'vstore');
@@ -2025,7 +2025,7 @@ class vstore
 			if ($sql->gen('SELECT item_inventory, item_name, cart_qty FROM #vstore_cart LEFT JOIN #vstore_items ON (cart_item = item_id) WHERE cart_session = "'.$this->cartId.'" AND cart_item = '.intval($id).' LIMIT 1'))
 			{
 				$inStock = $sql->fetch();
-				if ($inStock['item_inventory'] >= 0 && ($inStock['cart_qty'] + 1) > $inStock['item_inventory'])
+				if ($inStock['item_inventory'] > -1 && ($inStock['cart_qty'] + 1) > $inStock['item_inventory'])
 				{
 					e107::getMessage()->addWarning('Quantity of item "'.$inStock['item_name'].'" cart exceeds the number of items in stock!<br/>The quantity has been adjusted!', 'vstore');
 					return false;

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -1606,9 +1606,25 @@ class vstore
 	 * TODO - add a pref (multilan) containing the entire template which can be edited from within the admin area.
 	 * TODO - fallback to template in file if pref is empty.
 	 */
-	private function getEmailTemplate()
+	private function getEmailTemplate($type='default')
 	{
-		$template = e107::getTemplate('vstore', 'vstore_email', 'default');
+		if (empty($type))
+		{
+			$type = 'default';
+		}
+		$template = e107::pref('vstore', 'email_templates');
+		if (empty($template[$type]))
+		{
+			$template = e107::getTemplate('vstore', 'vstore_email', $type);
+			if (empty($template))
+			{
+				$template = e107::getTemplate('vstore', 'vstore_email', 'default');
+			}
+		}
+		else
+		{
+			$template = str_ireplace(array('[html]', '[/html'), '', $template[$type]);
+		}
 		return $template;
 	}
 

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -1493,6 +1493,12 @@ class vstore
 		}
 
 
+		if (!empty($transData))
+		{
+			$this->setCustomerUserclass(USERID, $items);
+		}
+
+
 		$insert['order_pay_gateway']    = $this->getGatewayType();
 		$insert['order_pay_status']     = empty($transData) ? 'incomplete' : 'complete';
 		$insert['order_pay_transid']    = $id;
@@ -1521,6 +1527,78 @@ class vstore
 		}
 
 
+	}
+
+	/**
+	 * Add userclass to customer
+	 *
+	 * @param int $userid Userid of the customer
+	 * @param array $items Array of order_items
+	 * @return void
+	 */
+	static function setCustomerUserclass($userid, $items)
+	{
+		$uc_global = e107::pref('vstore', 'customer_userclass');
+		if ($uc_global == -1)
+		{
+			$usr = e107::getSystemUser($userid, true);
+			// set userclass as defined in product
+			if (!empty($items) && is_array($items))
+			{
+				$sql = e107::getDb();
+				foreach ($items as $item) {
+					$uc = $sql->retrieve('vstore_items', 'item_userclass', 'item_id='.intval($item['id']));
+					if ($uc > 0 && $uc != 255)
+					{
+						$usr->addClass($uc);
+					}
+				}
+			}
+		}
+		elseif ($uc_global != 255)
+		{
+			$usr = e107::getSystemUser($userid, true);
+			// all classes except No One (inactive)
+			$usr->addClass($uc_global);
+		}
+	}
+
+	/**
+	 * Return the userclasses that will be added to customer
+	 *
+	 * @param array $items array of order_items
+	 * @return bool/string false, if no userclass, otherwise comma-separated list of userclasses
+	 */
+	static function getCustomerUserclass($items)
+	{
+		$uc_global = e107::pref('vstore', 'customer_userclass');
+		if ($uc_global == -1)
+		{
+			// set userclass as defined in product
+			if (!empty($items) && is_array($items))
+			{
+				$sql = e107::getDb();
+				$ucs = array();
+				foreach ($items as $item) {
+					$uc = $sql->retrieve('vstore_items', 'item_userclass', 'item_id='.intval($item['id']));
+					if ($uc > 0 && $uc != 255)
+					{
+						$ucs[] = $uc;
+					}
+				}
+				$ucs = array_unique($ucs);
+				if ($ucs && count($ucs))
+				{
+					return implode(',', $ucs);
+				}
+			}
+		}
+		elseif ($uc_global != 255)
+		{
+			// all classes except No One (inactive)
+			return ''.$uc_global;
+		}
+		return false;
 	}
 
 

--- a/vstore_setup.php
+++ b/vstore_setup.php
@@ -10,7 +10,7 @@
 **
 */
 
-class _blank_setup
+class vstore_setup
 {
 	
  	function install_pre($var)
@@ -34,7 +34,7 @@ class _blank_setup
 		(3, 'ITEM3', 'Product Three', NULL, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris libero magna, ornare sit amet nibh vitae, feugiat luctus nulla. Pellentesque placerat Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris libero magna, ornare sit amet nibh v', 1, 'array (\n  0 => \n  array (\n    \'path\' => \'{e_MEDIA_IMAGE}2016-04/logo_alone_1050_.jpg\',\n  ),\n  1 => \n  array (\n    \'path\' => \'\',\n  ),\n  2 => \n  array (\n    \'path\' => \'\',\n  ),\n  3 => \n  array (\n    \'path\' => \'\',\n  ),\n  4 => \n  array (\n    \'path\' => \'\',\n  ),\n)', 'array (\n  0 => \n  array (\n    \'path\' => \'\',\n    \'name\' => \'e107_banners.zip\',\n    \'id\' => \'171\',\n  ),\n  1 => \n  array (\n    \'path\' => \'\',\n    \'name\' => \'\',\n    \'id\' => \'\',\n  ),\n  2 => \n  array (\n    \'path\' => \'\',\n    \'name\' => \'\',\n    \'id\' => \'\',\n  ),\n  3 => \n  array (\n    \'path\' => \'\',\n    \'name\' => \'\',\n    \'id\' => \'\',\n  ),\n  4 => \n  array (\n    \'path\' => \'\',\n    \'name\' => \'\',\n    \'id\' => \'\',\n  ),\n)', '3.00', '2.00', '[html]<p>Some details go here.</p>[/html]', 'Here&#039;s a review of sorts. ', 1, 6, '', NULL, 'array (\n  \'caption\' => \'\',\n  \'src\' => \'\',\n)');
 
 		INSERT INTO `#vstore_cat` (`cat_id`, `cat_name`, `cat_description`, `cat_sef`, `cat_image`, `cat_info`, `cat_class`, `cat_order`) VALUES
-(1, 'General', 'Category Description here', 'general', '', '[html]<p>Some category details go here. </p>[/html]', '0', 0);
+		(1, 'General', 'Category Description here', 'general', '', '[html]<p>Some category details go here. </p>[/html]', '0', 0);
 		";
 		
 		if($sql->gen($dump))
@@ -51,9 +51,7 @@ class _blank_setup
 	function uninstall_options()
 	{
 	
-
 	}
-	
 
 	function uninstall_post($var)
 	{

--- a/vstore_sql.php
+++ b/vstore_sql.php
@@ -80,6 +80,7 @@ CREATE TABLE vstore_items (
   `item_link` varchar(255) DEFAULT NULL,
   `item_download` varchar(255) DEFAULT NULL,
   `item_related` text NOT NULL,
+	`item_userclass` SMALLINT(5) NOT NULL DEFAULT '0',
   PRIMARY KEY (`item_id`)
 ) ENGINE=MyISAM;
 


### PR DESCRIPTION
Implemented a solution to assign userclasses to a customer on purchase.
Userclasses will be assigned automatically when saving a transaction with a payment status = "complete" or when the order_status is set manually to "Completed".

There are 2 ways to define the userclass to assign:
**A) Globally via vStore preferences:** 
- "As defined in Product" > Each product can have it's own userclass. Just edit the product and select a userclass from the list.
- "No One (inactive)" > No userclass will be assigned. Product userclasses will be ignored.
- other userclasses > Selected userclass will be assigned. Product userclasses will be ignored.

**B) Product userclass**
In case the store preference is set to "As defined in Product", a dropdown is available in the products properties page. Selected userclass will be assigned. In case of "No One (inactive)", no userclass will be assigned.

In case the order status is changed from "Completed" to something else, the userclasses can't be removed automatically. In that case, a message is displayed which enables the storeadmin to jump to the customers profile to remove the classes manually. 

**DB update needed!**

**Implemented email template prefs** 
email template pref "default" = "Order confirmation"
email template pref "completed" = "Order completed" 
added to vstore preferences.
If not set, they will use the templates out of the templates folder.
Use of email template "Completed" still needs to get implemented