### PR TITLE
Ajax driven shopping cart; sitelinks install issue fixed

### DIFF
--- a/e_header.php
+++ b/e_header.php
@@ -26,8 +26,14 @@
 
                 $data = $vst->getCartData();
 
-                $count = count($data);
-
+                //$count = count($data);
+                // Sum up cart quantity for badge instead of only number of different products (items)
+                $count = 0;
+                if($data && count($data)){
+                    foreach ($data as $row) {
+                        $count += $row['cart_qty'];
+                    }
+                }
 
 
             }

--- a/e_sitelink.php
+++ b/e_sitelink.php
@@ -79,6 +79,7 @@ class vstore_sitelink // include plugin-folder in the name.
 	{
 
 		$vst = e107::getSingleton('vstore',e_PLUGIN.'vstore/vstore.class.php');
+		$sc = e107::getScBatch('vstore_plugin');
 
 		$data = $vst->getCartData();
 		$frm = e107::getForm();
@@ -101,7 +102,7 @@ e107::getDebug()->log($data);
 
 
 		$text .= '
-                    <div class="form-group">
+                    <div class="form-group alert alert-info">
                             <ul class="media-list list-unstyled">';
 
 		$total = 0;
@@ -119,8 +120,7 @@ e107::getDebug()->log($data);
 			$text .= '<li class="media">
 					<span class="media-object pull-left">'.$img.'</span>
 					<div class="media-body"><b>'.$item['item_name'].'</b><br />
-						<small class="text-muted smalltext">Qty: '.$item['cart_qty'].'</small><br />
-						'.number_format($subtotal,2).'
+						<span class="pull-right">'.$item['cart_qty'].' &times; '.$sc->sc_cart_currency_symbol().' '.number_format($subtotal,2).'</span>
 					</div>
 					</li>';
 
@@ -132,12 +132,15 @@ e107::getDebug()->log($data);
 
            $text .= '
 
-						<li class="media text-right"><h4>Total: '.number_format($total,2).'</h4></li>
+						<li class="media text-right"><h4>Total: '.$sc->sc_cart_currency_symbol().' '.number_format($total,2).'</h4></li>
                             </ul>
 
                     </div>
 
-                     <div><a class="btn btn-block btn-primary" href="'.e107::url('vstore','cart').'">Checkout</a></div>
+					<div>
+						 <a class="btn btn-block btn-danger" href="#" onclick="vstoreCartReset()"><i class="fa fa-trash-o" aria-hidden="true"></i> Clear cart</a>
+						 <a class="btn btn-block btn-primary col-xs-6" href="'.e107::url('vstore','cart').'"><i class="fa fa-shopping-cart" aria-hidden="true"></i> Checkout</a>
+					</div>
 				</div>			';
 
 		return $text;

--- a/e_sitelink.php
+++ b/e_sitelink.php
@@ -106,7 +106,7 @@ e107::getDebug()->log($data);
                             <ul class="media-list list-unstyled">';
 
 		$total = 0;
-
+		$itemcount = 0;
 
 
 		foreach($data as $item)
@@ -116,6 +116,7 @@ e107::getDebug()->log($data);
 
 		//	$text .= '<li>'.$img.$item['item_name'].'</li>';
 			$subtotal = ($item['item_price'] * $item['cart_qty']);
+			$itemcount += $item['cart_qty'];
 
 			$text .= '<li class="media">
 					<span class="media-object pull-left">'.$img.'</span>
@@ -134,7 +135,7 @@ e107::getDebug()->log($data);
 
 						<li class="media text-right"><h4>Total: '.$sc->sc_cart_currency_symbol().' '.number_format($total,2).'</h4></li>
                             </ul>
-
+						<div id="vstore-item-count" class="hidden">'.$itemcount.'</div>
                     </div>
 
 					<div>

--- a/e_url.php
+++ b/e_url.php
@@ -21,8 +21,13 @@ class vstore_url // plugin-folder + '_url'
 	{
 		$config = array();
 
+		$config['download'] = array(
+			'regex'			=> '^{alias}\/download/([\d]*)$',
+			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?download=$1&',
+			'sef'			=> '{alias}/download/{item_id}'
+		);
+		
 		$config['cancel'] = array(
-
 			'regex'			=> '^vstore/checkout/cancel/?$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=cancel',
 			'sef'			=>  'vstore/checkout/cancel/',
@@ -37,37 +42,34 @@ class vstore_url // plugin-folder + '_url'
 
 
 		$config['checkout'] = array(
-
-			'regex'			=> '^vstore/checkout/?$',
+			'regex'			=> '^{alias}/checkout/?$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=checkout',
-			'sef'			=>  'vstore/checkout/',
+			'sef'			=>  '{alias}/checkout/',
 		);
 
 
 		$config['addtocart'] = array(
-			'regex'			=> '^vstore/cart/add/([\d]*)$',
+			'regex'			=> '^{alias}/cart/add/([\d]*)$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=cart&add=$1',
-			'sef'			=>  'vstore/cart/add/{item_id}',
+			'sef'			=>  '{alias}/cart/add/{item_id}',
 		);
 
 		$config['cart'] = array(
-			'regex'			=> '^vstore/cart/?\??(.*)$',
+			'regex'			=> '^{alias}/cart/?\??(.*)$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=cart&$1',
-			'sef'			=>  'vstore/cart/',
+			'sef'			=>  '{alias}/cart/',
 		);
 
 		$config['index'] = array(
 			'regex'			=> '^{alias}\/?([\?].*)?\/?$',
-			'sef'			=> '{alias}/',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php$1',
-
+			'sef'			=> '{alias}/'
 		);
 
 		$config['product'] = array(
 			'regex'			=> '^{alias}/([^\/]*)/([\d]*)/(.*)',
-			'sef'			=> '{alias}/{cat_sef}/{item_id}/{item_sef}',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?item=$2',
-
+			'sef'			=> '{alias}/{cat_sef}/{item_id}/{item_sef}'
 		);
 
 		$config['subcategory'] = array(
@@ -76,13 +78,12 @@ class vstore_url // plugin-folder + '_url'
 			'sef'			=> '{alias}/{cat_sef}/{subcat_sef}/'
 		);
 
-
 		$config['category'] = array(
 			'regex'			=> '^{alias}\/([^\/\?\=]*)\/?\??',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?catsef=$1&',
 			'sef'			=> '{alias}/{cat_sef}/'
 		);
-		
+
 		return $config;
 	}
 	

--- a/js/vstore.js
+++ b/js/vstore.js
@@ -112,4 +112,85 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 		}
 	};
 
+	/**
+	 * @type {{attach: e107.behaviors.vstoreCartAdd.attach}}
+	 */
+	e107.behaviors.vstoreCartAdd = {
+		attach: function (context, settings)
+		{
+			$(context).find('.vstore-add').once('vstore-cart-add').each(function (e)
+			{
+				$(this).click(function(e){
+					e.preventDefault();
+
+					var url = settings.vstore.cart.url;
+					var itemid = $(this).data('vstore-item');
+
+					url += (url.indexOf('?')>=0 ? '&' : '?') + 'mode=cart&add=' + itemid;
+					
+
+					$.get(url, function(resp){
+						var msg = (typeof resp != 'undefined') ? resp : '';
+						if (msg.substr(0, 2) == 'ok')
+						{
+							msg = msg.substr(2);
+							$('#vstore-cart-dropdown').replaceWith(msg);
+							$('#vstore-cart-icon .badge').html($('#vstore-cart-dropdown span.media-object').length);
+							return;
+						}
+
+						$('#uiAlert').html(msg);
+
+					});
+				});
+			});
+		}
+	};
+
 })(jQuery);
+
+/** 
+ * Reset/empty cart and update menu
+ */
+function vstoreCartReset()
+{
+	var url = e107.settings.vstore.cart.url;
+
+	url += (url.indexOf('?')>=0 ? '&' : '?') + 'reset=1';
+	
+
+	$.get(url, function(resp){
+		var msg = (typeof resp != 'undefined') ? resp : '';
+		if (msg.substr(0, 2) == 'ok')
+		{
+			msg = msg.substr(2);
+			$('#vstore-cart-dropdown').replaceWith(msg);
+			$('#vstore-cart-icon .badge').html(0);
+			return;
+		}
+	});
+
+};
+
+/**
+ * Refresh cart menu item
+ */
+function vstoreCartRefresh()
+{
+	var url = e107.settings.vstore.cart.url;
+
+	url += (url.indexOf('?')>=0 ? '&' : '?') + 'refresh=1';
+	
+
+	$.get(url, function(resp){
+		var msg = (typeof resp != 'undefined') ? resp : '';
+		if (msg.substr(0, 2) == 'ok')
+		{
+			msg = msg.substr(2);
+			$('#vstore-cart-dropdown').replaceWith(msg);
+			$('#vstore-cart-icon .badge').html(0);
+			return;
+		}
+	});
+
+};

--- a/js/vstore.js
+++ b/js/vstore.js
@@ -133,12 +133,15 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 						var msg = (typeof resp != 'undefined') ? resp : '';
 						if (msg.substr(0, 2) == 'ok')
 						{
+							// if ok, update cart menu with new content
 							msg = msg.substr(2);
 							$('#vstore-cart-dropdown').replaceWith(msg);
-							$('#vstore-cart-icon .badge').html($('#vstore-cart-dropdown span.media-object').length);
+							var itemcount = $('#vstore-item-count').text();
+							if (itemcount <= 0) itemcount = 0;
+							$('#vstore-cart-icon .badge').html(itemcount);
 							return;
 						}
-
+						// Print our any (error) message 
 						$('#uiAlert').html(msg);
 
 					});
@@ -163,6 +166,7 @@ function vstoreCartReset()
 		var msg = (typeof resp != 'undefined') ? resp : '';
 		if (msg.substr(0, 2) == 'ok')
 		{
+			// if ok, update cart menu with new content
 			msg = msg.substr(2);
 			$('#vstore-cart-dropdown').replaceWith(msg);
 			$('#vstore-cart-icon .badge').html(0);
@@ -186,9 +190,12 @@ function vstoreCartRefresh()
 		var msg = (typeof resp != 'undefined') ? resp : '';
 		if (msg.substr(0, 2) == 'ok')
 		{
+			// if ok, update cart menu with new content
 			msg = msg.substr(2);
 			$('#vstore-cart-dropdown').replaceWith(msg);
-			$('#vstore-cart-icon .badge').html(0);
+			var itemcount = $('#vstore-item-count').text();
+			if (itemcount <= 0) itemcount = 0;
+			$('#vstore-cart-icon .badge').html(itemcount);
 			return;
 		}
 	});

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,8 +13,8 @@
 		<link url="admin_config.php" description="" icon="images/vstore_32.png" iconSmall="images/vstore_16.png" icon128="images/vstore_128.png" primary="true" >LAN_CONFIGURE</link>
 	</adminLinks>
 	<siteLinks>
-		<link url="{e_PLUGIN}vstore/vstore.php" sef='index' perm="admin" >LAN_PLUGIN_VSTORE_NAME</link>
-		<link url="#"  description="Shopping Cart" perm="everyone" function="vstore::storeCart" >LAN_PLUGIN_VSTORE_CARTICON</link>
+		<link url="{e_PLUGIN}vstore/vstore.php" sef='index' perm="member" >LAN_PLUGIN_VSTORE_NAME</link>
+		<link url="#"  description="Shopping Cart" perm="member" function="storeCart" >LAN_PLUGIN_VSTORE_CARTICON</link>
 	</siteLinks>
 	<pluginPrefs>
 		<pref name='currency'>USD</pref>

--- a/templates/vstore_template.php
+++ b/templates/vstore_template.php
@@ -43,26 +43,47 @@ $VSTORE_TEMPLATE['list']['end']         = '</div>';
 
 
 $VSTORE_TEMPLATE['menu']['start'] =  '';
-$VSTORE_TEMPLATE['menu']['item'] =  '
-			{SETIMAGE: w=320&h=250&crop=1}
-			<div class="vstore-product-list col-sm-12 col-lg-12 col-md-12">
-	                        <div class="thumbnail">
-                            <a href="{ITEM_URL}">{ITEM_PIC}</a>
-                            <div class="caption">
-                                <h4><a href="{ITEM_URL}">{ITEM_NAME}</a></h4>
-                                <p class="item-description">{ITEM_DESCRIPTION}</p>
-                                <div class="row">
-								<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-									<p class="lead">{ITEM_PRICE}</p>
-								</div>
-								<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-									{ITEM_ADDTOCART}
-								</div>
-							</div>
-                            </div>
+// $VSTORE_TEMPLATE['menu']['item'] =  '
+// 			{SETIMAGE: w=320&h=250&crop=1}
+// 			<div class="vstore-product-list col-sm-12 col-lg-12 col-md-12">
+// 	                        <div class="thumbnail">
+//                             <a href="{ITEM_URL}">{ITEM_PIC}</a>
+//                             <div class="caption">
+//                                 <h4><a href="{ITEM_URL}">{ITEM_NAME}</a></h4>
+//                                 <p class="item-description">{ITEM_DESCRIPTION}</p>
+//                                 <div class="row">
+// 								<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+// 									<p class="lead">{ITEM_PRICE}</p>
+// 								</div>
+// 								<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+// 									{ITEM_ADDTOCART}
+// 								</div>
+// 							</div>
+//                             </div>
 
-                        </div>
-                    </div>';
+//                         </div>
+//                     </div>';
+$VSTORE_TEMPLATE['menu']['item'] =  '
+			{SETIMAGE: w=100&h=100&crop=1}
+			<div class="vstore-product-list col-sm-12 col-lg-12 col-md-12">
+				<div class="thumbnail" style="height:auto;">
+					<div class="caption">
+						<div class="row">
+							<a href="{ITEM_URL}" class="col-xs-4">{ITEM_PIC}</a>
+							<h4 class="col-xs-8"><a href="{ITEM_URL}">{ITEM_NAME}</a></h4>
+						</div>
+						<!-- <p class="item-description">{ITEM_DESCRIPTION}</p> -->
+						<div class="row">
+							<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+								<p class="lead">{ITEM_PRICE}</p>
+							</div>
+							<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+								{ITEM_ADDTOCART: class=btn btn-sm btn-success vstore-add&class0=btn btn-sm btn-default disabled}
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>';
 
 $VSTORE_TEMPLATE['menu']['end'] =  '';
 // Item View.

--- a/templates/vstore_template.php
+++ b/templates/vstore_template.php
@@ -16,7 +16,7 @@ $VSTORE_TEMPLATE['list']['item']    =  '
 								                               </p>
 								                                <div class="row">
 								                                    <div class="col-md-5"><a class="item-price" href="{ITEM_URL}">{ITEM_PRICE}</a></div>
-								                                    <div class="col-md-7 text-right">{ITEM_ADDTOCART: class=btn btn-sm btn-success&class0=btn btn-sm btn-default disabled}</div>
+								                                    <div class="col-md-7 text-right">{ITEM_ADDTOCART: class=btn btn-sm btn-success vstore-add&class0=btn btn-sm btn-default disabled}</div>
 								                                </div>
 
 							                            </div>

--- a/vstore.php
+++ b/vstore.php
@@ -12,6 +12,8 @@ if (!defined('e107_INIT'))
 e107::js('vstore','js/jquery.zoom.min.js');
 e107::js('vstore','js/vstore.js');
 
+e107::js('settings', array('vstore' => array('cart' => array('url' => e107::url('vstore', 'cart').'cart.php'))));
+
 $vstore = e107::getSingleton('vstore',e_PLUGIN.'vstore/vstore.class.php');
 $vstore->init();
 require_once(HEADERF);

--- a/vstore_menu.php
+++ b/vstore_menu.php
@@ -4,6 +4,8 @@
 require_once(e_PLUGIN.'vstore/vstore.class.php');
 $vst = new vstore;
 
+e107::js('settings', array('vstore' => array('cart' => array('url' => e107::url('vstore', 'cart').'cart.php'))));
+
 
 $category = 1;  //TODO e_menu config.
 $caption = "Products";


### PR DESCRIPTION
**fixed issue #41**: sitelinks function is not inserted during installation

**Ajax driven shopping cart**: This is implemented and working, even with the vstore_menu.
- That means, adding an item doesn't redirect the page to the shopping cart to add. Instead this is done via ajax in the background and the shopping cart nav dropdown and badge is updated afterwards.
- Added also a button to the dropdown to clear the shopping cart.
- The dropdown now gets also updated in case of payment method bank transfer (where the page isn't reloaded).
- Rearranged the layout of the vstore_menu as i think the displayed items took to many place...

**download of purchased digital content #30 #5**: In case a product has (at the time it has been purchased) a digital content "attached", the download link will be included in the "Order confirmation" and "Order completed" emails.
The download is valid in case the order is "Completed" or the "New" and the payment is "complete".
In every other case, the download will be denied.
The user must be logged in to access the download.