### PR TITLE
New pref: Custom-CSS; Reorganized Ajax; Fixed inventory issue

### DIFF
--- a/admin_config.php
+++ b/admin_config.php
@@ -1353,7 +1353,7 @@ class vstore_cat_ui extends e_admin_ui
 	
 			if ($count > 0)
 			{
-				$result = $this->check_sef($sef, $table, $sef_field, $id_field, $id_value, ++$try);
+				$result = $this->fix_sef($sef, $table, $sef_field, $id_field, $id_value, ++$try);
 			}
 	
 			return $result;

--- a/admin_config.php
+++ b/admin_config.php
@@ -13,7 +13,7 @@ e107::css('inline',"
 
 	img.level-1 { margin:0 5px 0 15px; }
 	item-inventory { font-weight: bold }
-
+	#custom-css{ font-family: monospace; }
 ");
 
 require_once('vstore.class.php');
@@ -846,7 +846,7 @@ Secret Key 	secret_key 	Default : null
 Region 	region
  */
 		// optional
-		protected $preftabs = array(LAN_GENERAL, "Emails", "How to Order", "Admin Area", "Check-Out");
+		protected $preftabs = array(LAN_GENERAL, "Emails", "How to Order", "Admin Area", "Check-Out", "Custom CSS");
 
 
 		protected $prefs = array(
@@ -862,7 +862,7 @@ Region 	region
 			'sender_name'               => array('title'=> 'Sender Name', 'tab'=>1, 'type'=>'text', 'writeParms'=>array('placeholder'=>'Sales Department'), 'help'=>'Leave blank to use system default','multilan'=>false),
 			'sender_email'              => array('title'=> LAN_EMAIL, 'tab'=>1, 'type'=>'text', 'writeParms'=>array('placeholder'=>'orders@mysite.com'), 'help'=>'Leave blank to use system default', 'multilan'=>false),
 			'merchant_info'             => array('title'=> "Merchant Name/Address", 'tab'=>1, 'type'=>'textarea', 'writeParms'=>array('placeholder'=>'My Store Inc. etc.'), 'help'=>'Will be displayed on customer email.', 'multilan'=>false),
-			'email_templates'           => array('title'=> "Email templates", 'tab'=>1, 'type'=>'method'), //, 'writeParms'=>array('placeholder'=>'My Store Inc. etc.'), 'help'=>'Will be displayed on customer email.', 'multilan'=>false),
+			'email_templates'           => array('title'=> "Email templates", 'tab'=>1, 'type'=>'method'),
 
 
 			'admin_items_perpage'	    => array('title'=> 'Products per page', 'tab'=>3, 'type'=>'number', 'help'=>''),
@@ -871,6 +871,7 @@ Region 	region
 			'additional_fields'         => array('title'=>'Additional Fields', 'tab'=>4, 'type'=>'method'),
 			'admin_confirm_order'		=> array('title'=> 'Confirm order', 'tab'=>4, 'type'=>'bool', 'help'=>'If ON, the customer has to confirm his order after selecting the payment method on the checkout page!'),
 
+			'custom_css'	            => array('title'=> 'Custom CSS', 'tab'=>5, 'type' => 'textarea', 'data' => 'str', 'width' => '100%', 'readParms' => '', 'writeParms' => array('cols'=> 80, 'rows' => 10, 'size'=>'block-level'), 'help'=>'Use this field to enter any vstore related custom css, without the need to edit any source files.'),
 		);
 
 

--- a/e_sitelink.php
+++ b/e_sitelink.php
@@ -120,12 +120,14 @@ e107::getDebug()->log($data);
 			$itemvarstring = '';
 			if (!empty($item['cart_item_vars']))
 			{
-				$itemvars = vstore::item_vars_toArray($item['cart_item_vars']);
+				$itemprop = vstore::getItemVarProperties($item['cart_item_vars'], $item['item_price']);
 
-				foreach($itemvars as $k => $v)
+				if ($itemprop)
 				{
-					$itemvarstring .= ($itemvarstring ? ' / ' : '') . vstore::getItemVarString($k, $v);
+					$itemvarstring = $itemprop['variation'];
+					$subtotal = ($item['item_price'] + $itemprop['price']) * $item['cart_qty'];
 				}
+
 				if (!empty($itemvarstring))
 				{
 					$itemvarstring = '<br/><span class="vstore-cart-item-var small">' . $itemvarstring . '</span>';

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -1034,6 +1034,12 @@ class vstore
 
 	}
 
+	/**
+	 * Get status string from key or (if key is empty) complete status array
+	 *
+	 * @param string $key
+	 * @return array/string
+	 */
 	public static function getStatus($key=null)
 	{
 		if(!empty($key))
@@ -1045,6 +1051,12 @@ class vstore
 
 	}
 
+	/**
+	 * Get email type string from key or (if key is empty) complete email type array
+	 *
+	 * @param string $key
+	 * @return array/string
+	 */
 	public static function getEmailTypes($type=null)
 	{
 		if(!empty($type))
@@ -1056,6 +1068,11 @@ class vstore
 
 	}
 
+	/**
+	 * Return the shippingFields array
+	 *
+	 * @return array
+	 */
 	public static function getShippingFields()
 	{
 		return self::$shippingFields;
@@ -1184,7 +1201,11 @@ class vstore
 
 	}
 
-
+	/**
+	 * Render customer information form
+	 *
+	 * @return string the form
+	 */
 	private function renderForm()
 	{
 
@@ -1369,41 +1390,15 @@ class vstore
 		$this->get['mode'] = $mode;
 	}
 
+	/**
+	 * Render the vstore pages
+	 *
+	 * @return string
+	 */
 	public function render()
 	{
 
 		$ns = e107::getRender();
-
-		// if($this->get['add'])
-		// {
-		// 	if(e_AJAX_REQUEST)
-		// 	{
-		// 		$js = e107::getJshelper();
-		// 		$js->_reset();
-		// 		$itemid = $this->get['add'];
-		// 		$itemvars = $this->get['itemvar'];
-		// 		if (!$this->addToCart($itemid, $itemvars))
-		// 		{
-		// 			$msg = e107::getMessage()->render('vstore');
-		// 			ob_clean();
-		// 			$js->addTextResponse($msg)->sendResponse();
-		// 			exit;
-		// 		}
-		// 		else
-		// 		{
-		// 			$sl = new vstore_sitelink();
-		// 			$msg = $sl->storeCart();
-		// 		}
-		// 		ob_clean();
-		// 		$js->addTextResponse('ok '.$msg)->sendResponse();
-		// 		exit;
-		// 	}
-		// 	$bread = $this->breadcrumb();
-		// 	$text = $this->cartView();
-		// 	$text = e107::getMessage()->render('vstore') . $text;
-		// 	$ns->tablerender($this->captionBase, $bread.$text, 'vstore-cart-view');
-		// 	return null;
-		// }
 
 		if (!empty($this->get['download']))
 		{
@@ -1413,37 +1408,8 @@ class vstore
 				return null;
 			}
 		}
-		
-		// if(!empty($this->get['reset']))
-		// {
-		// 	if(e_AJAX_REQUEST)
-		// 	{
-		// 		$this->resetCart();
-		// 		$sl = new vstore_sitelink();
-		// 		$msg = $sl->storeCart();
-		// 		ob_clean();
-		// 		$js = e107::getJshelper();
-		// 		$js->_reset();
-		// 		$js->addTextResponse('ok '.$msg)->sendResponse();
-		// 		exit;
-		// 	}
-		// }
-		
-		// if(!empty($this->get['refresh']))
-		// {
-		// 	if(e_AJAX_REQUEST)
-		// 	{
-		// 		$sl = new vstore_sitelink();
-		// 		$msg = $sl->storeCart();
-		// 		ob_clean();
-		// 		$js = e107::getJshelper();
-		// 		$js->_reset();
-		// 		$js->addTextResponse('ok '.$msg)->sendResponse();
-		// 		exit;
-		// 	}
-		// }
 
-
+		
 		if($this->getMode() == 'return')
 		{
 			// print_a($this->post);
@@ -1477,9 +1443,6 @@ class vstore
 			$ns->tablerender($this->captionBase, $bread.$text, 'vstore-cart-list');
 			return null;
 		}
-
-
-
 
 
 		if($this->get['item'])
@@ -1521,7 +1484,11 @@ class vstore
 
 
 
-
+	/**
+	 * Render breadcrumb
+	 *
+	 * @return string the breadcrumb
+	 */
 	private function breadcrumb()
 	{
 		$frm = e107::getForm();
@@ -1586,16 +1553,24 @@ class vstore
 	}
 
 
+	/**
+	 * Return the active payment gateway information
+	 *
+	 * @return array
+	 */
 	private function getActiveGateways()
 	{
-
 
 		return $this->active;
 
 	}
 
 
-
+	/**
+	 * Render checkout complete message
+	 *
+	 * @return string
+	 */
 	private function checkoutComplete()
 	{
 		$text = e107::getMessage()->render('vstore');
@@ -1606,7 +1581,11 @@ class vstore
 	}
 
 
-
+	/**
+	 * Render checkout page to enter the customers shipping information
+	 *
+	 * @return string
+	 */
 	private function checkoutView()
 	{
 		$active = $this->getActiveGateways();
@@ -1665,8 +1644,14 @@ class vstore
 	}
 
 
-	//  // help http://stackoverflow.com/questions/20756067/omnipay-paypal-integration-with-laravel-4
-	// https://www.youtube.com/watch?v=EvfFN0-aBmI
+	/**
+	 * Process the payment via selected payment gateway
+	 *
+	 * @see http://stackoverflow.com/questions/20756067/omnipay-paypal-integration-with-laravel-4
+	 * @see https://www.youtube.com/watch?v=EvfFN0-aBmI
+	 * @param string $mode
+	 * @return boolean
+	 */
 	private function processGateway($mode = 'init')
 	{
 		$type = $this->getGatewayType();
@@ -1877,7 +1862,14 @@ class vstore
 		}
 	}
 
-
+	/**
+	 * Build a order reference number out of the order_id, first- & lastname
+	 *
+	 * @param int $id
+	 * @param string $firstname
+	 * @param string $lastname
+	 * @return string
+	 */
 	private function getOrderRef($id,$firstname,$lastname)
 	{
 		$text = substr($firstname,0,2);
@@ -1890,6 +1882,14 @@ class vstore
 	}
 
 
+	/**
+	 * Save the transaction to the database
+	 *
+	 * @param string $id transaction id
+	 * @param array $transData transaction data
+	 * @param array $items purchased item
+	 * @return void
+	 */
 	private function saveTransaction($id, $transData, $items)
 	{
 
@@ -2060,8 +2060,12 @@ class vstore
 
 
 	/**
-	 * TODO - add a pref (multilan) containing the entire template which can be edited from within the admin area.
-	 * TODO - fallback to template in file if pref is empty.
+	 * Get the current email template
+	 * If it isn't defined in the admin area, load the template from the template folder
+	 *
+	 * @todo add a pref (multilan) containing the entire template which can be edited from within the admin area.
+	 * @param string $type email type 
+	 * @return string the template
 	 */
 	private function getEmailTemplate($type='default')
 	{
@@ -2091,7 +2095,14 @@ class vstore
 
 
 
-
+	/**
+	 * Send an email to the customer
+	 *
+	 * @param string $templateKey the email type
+	 * @param string $ref the order ref.
+	 * @param array $insert email contents
+	 * @return void
+	 */
 	function emailCustomer($templateKey='default', $ref, $insert=array())
 	{
 		$tp = e107::getParser();
@@ -2136,7 +2147,12 @@ class vstore
 
 
 
-
+	/**
+	 * Update the items inventory based on the given json string
+	 *
+	 * @param string $json
+	 * @return void
+	 */
 	private function updateInventory($json)
 	{
 		$sql = e107::getDb();
@@ -2167,12 +2183,17 @@ class vstore
 				{
 					e107::getMessage()->addDebug("Unlimited item not reduced: ".$row['name']." (".$row['id'].")");
 				}
-		}
+			}
 		}
 
 	}
 
-
+	/**
+	 * Return the icon for the given gateway
+	 *
+	 * @param string $type
+	 * @return string
+	 */
 	private function getGatewayIcon($type='')
 	{
 		$text = !empty(self::$gateways[$type]) ? self::$gateways[$type]['icon'] : '';
@@ -2180,32 +2201,61 @@ class vstore
 
 	}
 
-
-	public static function getGatewayTitle($key)
+	/**
+	 * Return the title/name of the given gateway
+	 *
+	 * @param string $type
+	 * @return string
+	 */
+	public static function getGatewayTitle($type)
 	{
-		return self::$gateways[$key]['title'];
+		return self::$gateways[$type]['title'];
 
 	}
 
 
+	/**
+	 * Return the type of the current gateway
+	 *
+	 * @param string $type
+	 * @return string
+	 */
 	private function getGatewayType()
 	{
 		return $_SESSION['vstore']['gateway']['type'];
 	}
 
 
+	/**
+	 * Set the type of the current gateway
+	 *
+	 * @param string $type
+	 * @return void
+	 */
 	private function setGatewayType($type='')
 	{
 		 $_SESSION['vstore']['gateway']['type'] = $type;
 	}
 
 
-	
+	/**
+	 * Set the number of items per page
+	 *
+	 * @param int $num
+	 * @return void
+	 */
 	public function setPerPage($num)
 	{
 		$this->perPage = intval($num);	
 	}
 
+	/**
+	 * Update the cart
+	 *
+	 * @param string $type (modify, remove)
+	 * @param array $array of the ids and item used for modify or remove
+	 * @return void
+	 */
 	protected function updateCart($type = 'modify', $array)
 	{
 		$sql = e107::getDb();
@@ -2275,6 +2325,12 @@ class vstore
 	}
 
 
+	/**
+	 * Reset the cart
+	 * Remove all items from the cart
+	 *
+	 * @return void
+	 */
 	protected function resetCart()
 	{
 		// Delete cart from database
@@ -2287,7 +2343,11 @@ class vstore
 	}
 
 
-
+	/**
+	 * Return the current cart id
+	 *
+	 * @return string
+	 */
 	protected function getCartId()
 	{
 		if(!empty($_COOKIE["cartId"]))
@@ -2305,7 +2365,13 @@ class vstore
 		}
 	}
 
-
+	/**
+	 * Render the list of categories
+	 *
+	 * @param integer $parent 0 = root categories
+	 * @param boolean $np true = render nextprev control; false = dont't render nextprev
+	 * @return string
+	 */
 	public function categoryList($parent=0,$np=false)
 	{
 		
@@ -2384,12 +2450,19 @@ class vstore
 	}
 		
 	
+	/**
+	 * Render the list of products
+	 *
+	 * @param integer $category selected category id
+	 * @param boolean $np	render nextpref yes/no
+	 * @param string $templateID name of the template to use
+	 * @return string
+	 */
 	public function productList($category=1,$np=false,$templateID = 'list')
 	{
 
 
 
-//		if(!$data = e107::getDb()->retrieve('SELECT SQL_CALC_FOUND_ROWS * FROM #vstore_items WHERE cat_active=1 AND item_active=1 AND item_cat = '.intval($category).' ORDER BY item_order LIMIT '.$this->from.','.$this->perPage, true))
 		if(!$data = e107::getDb()->retrieve('SELECT SQL_CALC_FOUND_ROWS *, cat_active FROM #vstore_items LEFT JOIN #vstore_cat ON (item_cat = cat_id) WHERE cat_active=1 AND item_active=1 AND item_cat = '.intval($category).' ORDER BY item_order LIMIT '.$this->from.','.$this->perPage, true))
 		{
 
@@ -2445,7 +2518,12 @@ class vstore
 	}	
 	
 	
-	
+	/**
+	 * Render a single product/item
+	 *
+	 * @param integer $id item_id
+	 * @return string
+	 */
 	protected function productView($id=0)
 	{
 		if(!$row = e107::getDb()->retrieve('SELECT * FROM #vstore_items WHERE item_active=1 AND item_id = '.intval($id).'  LIMIT 1',true))
@@ -2515,7 +2593,6 @@ class vstore
 			}
 		}
 		
-		//if(!empty($data['cat_info']))
 		if (!empty(e107::pref('vstore', 'howtoorder')))
 		{
 			$tabData['howto']		= array('caption'=>'How to Order', 'text'=> $tmpl['item']['howto']);
@@ -2525,19 +2602,21 @@ class vstore
 		{
 			$text .= $frm->tabs($tabData);
 		}
-	//	print_a($text);
+
 		$parsed = $tp->parseTemplate($text, true, $this->sc);
 
 		return $parsed;
 	}
 	
 	
-	protected function cartData()
-	{
-
-	}
-	
-	
+	/**
+	 * Add a single item to the cart
+	 * if the item is already on the list increase the quantity by 1
+	 *
+	 * @param int $id item_id
+	 * @param array $itemvars array of item variations
+	 * @return bool true on success
+	 */	
 	protected function addToCart($id, $itemvars=false)
 	{
 		if (USERID === 0){
@@ -2598,6 +2677,12 @@ class vstore
 	
 	}
 
+	/**
+	 * fix the item variation array to be used in following processes
+	 *
+	 * @param array $itemvars
+	 * @return array
+	 */
 	private function fixItemVarArray($itemvars)
 	{
 		if (!is_array($itemvars))
@@ -2620,6 +2705,12 @@ class vstore
 		return $result;
 	}
 
+	/**
+	 * Format the item variation array for use in the db field
+	 *
+	 * @param array $itemvarsarray
+	 * @return string
+	 */
 	public static function item_vars_toDB($itemvarsarray)
 	{
 		if (!is_array($itemvarsarray))
@@ -2631,6 +2722,12 @@ class vstore
 		return $result;
 	}
 
+	/**
+	 * Format the item variation string to an array
+	 *
+	 * @param string $itemvarsstring
+	 * @return array
+	 */
 	public static function item_vars_toArray($itemvarsstring)
 	{
 		if (empty($itemvarsstring) || strpos($itemvarsstring, '|') === false)
@@ -2701,14 +2798,22 @@ class vstore
 
 	}
 
-
+	/**
+	 * Fetch the cart data 
+	 *
+	 * @return array
+	 */
 	public function getCartData()
 	{
 		return e107::getDb()->retrieve('SELECT c.*, i.*, cat.cat_name, cat.cat_sef FROM `#vstore_cart` AS c LEFT JOIN `#vstore_items` as i ON (c.cart_item = i.item_id) LEFT JOIN `#vstore_cat` as cat ON (i.item_cat = cat.cat_id) WHERE c.cart_session = "'.$this->cartId.'" AND c.cart_status ="" ', true);
 	}
 
 
-
+	/**
+	 * Render the cart 
+	 *
+	 * @return string
+	 */
 	protected function cartView()
 	{
 		if(!$data = $this->getCartData() )
@@ -2860,19 +2965,29 @@ class vstore
 		$this->setCheckoutData($checkoutData);
 
 		return $text;
-	//	$ns->tablerender("Shopping Cart",$text,'vstore-view-cart');
-		
 
 	}
 	
 
-
+	/**
+	 * Store checkout data in session variable
+	 *
+	 * @param array $data data to store in session
+	 * @return void
+	 */
 	private function setCheckoutData($data=array())
 	{
 		$_SESSION['vstore']['checkout'] = $data;
 		$_SESSION['vstore']['checkout']['currency'] = $this->currency;
 	}
 
+
+	/**
+	 * Store shipping data in session variable
+	 *
+	 * @param array $data data to store
+	 * @return void
+	 */
 	private function setShippingData($data=array())
 	{
 		$pref = e107::pref('vstore');
@@ -2911,12 +3026,23 @@ class vstore
 
 	}
 
-	private function getShippingData($data=array())
+	/**
+	 * Return the shipping data from the session variable
+	 *
+	 * @return array
+	 */
+	private function getShippingData()
 	{
 		return $_SESSION['vstore']['shipping'];
 	}
 
 
+	/**
+	 * Return the checkoutdata from the session variable
+	 *
+	 * @param int $id  
+	 * @return array
+	 */
 	private function getCheckoutData($id=null)
 	{
 		if(!empty($id))
@@ -2927,12 +3053,18 @@ class vstore
 		return $_SESSION['vstore']['checkout'];
 	}
 	
-	
+	/**
+	 * Process a download request of a downloadable item
+	 *
+	 * @param int $item_id
+	 * @return bool false on error	 
+	 */
 	private function downloadFile($item_id=null)
 	{
 		if ($item_id == null || intval($item_id) <= 0)
 		{
 			e107::getMessage()->addDebug('Download id "'.intval($item_id).'" to download missing or invalid!','vstore');
+			return false;
 		}
 
 		if (USERID === 0)
@@ -2954,6 +3086,7 @@ class vstore
 		else
 		{
 			e107::getMessage()->addError('Download id  "'.intval($item_id).'" doesn\'t contain a file to download!', 'vstore');
+			return false;
 		}
 
 	}
@@ -3005,7 +3138,12 @@ class vstore
 		return false;
 	}
 
-	
+	/**
+	 * Is the item (incl. the category of the item) active?
+	 *
+	 * @param int $itemid
+	 * @return boolean true = active; false = inactive
+	 */	
 	private function isItemActive($itemid)
 	{
 		if (intval($itemid) <= 0)
@@ -3021,6 +3159,13 @@ class vstore
 		return false;
 	}
 
+	/**
+	 * Get the item variation string from the given id and value
+	 *
+	 * @param int $itemvarid
+	 * @param string $itemvarvalue
+	 * @return string
+	 */
 	public static function getItemVarString($itemvarid, $itemvarvalue)
 	{
 		if ($itemvarid == null || $itemvarid <= 0)
@@ -3056,5 +3201,3 @@ class vstore
 	
 	
 }
-
-

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -133,7 +133,7 @@ class vstore_plugin_shortcodes extends e_shortcode
 			$text .= "
 					<tr>
 						<td>".$desc."</td>
-						<td class='text-right'>".number_format($this->curSymbol.$item['price'], 2)."</td>
+						<td class='text-right'>".$this->curSymbol.number_format($item['price'], 2)."</td>
 						<td class='text-right'>".$item['quantity']."</td>
 						<td class='text-right'>".$this->curSymbol.number_format($item['price'] * $item['quantity'], 2)."</tdclass>
 					</tr>";

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -1025,6 +1025,10 @@ class vstore
 			$this->get['cat'] = vartrue($this->categorySEF[$sef],0);
 		}
 
+		// Check for ajax requests and process them first 
+		$this->process_ajax();
+
+		// In case this is not an ajax request continue with processing
 		$this->process();
 		
 
@@ -1058,6 +1062,82 @@ class vstore
 	}
 
 
+	/**
+	 * Handle & process all ajax requests 
+	 *
+	 * @return void
+	 */
+	private function process_ajax()
+	{
+		if(e_AJAX_REQUEST)
+		{
+			// Process only ajax requests
+			if($this->get['add'])
+			{
+				// Add item to cart
+				$js = e107::getJshelper();
+				$js->_reset();
+				$itemid = $this->get['add'];
+				$itemvars = $this->get['itemvar'];
+				if (!$this->addToCart($itemid, $itemvars))
+				{
+					$msg = e107::getMessage()->render('vstore');
+					ob_clean();
+					$js->addTextResponse($msg)->sendResponse();
+					exit;
+				}
+				else
+				{
+					include_once 'e_sitelink.php';
+					$sl = new vstore_sitelink();
+					$msg = $sl->storeCart();
+				}
+				ob_clean();
+				$js->addTextResponse('ok '.$msg)->sendResponse();
+				exit;
+			}
+				
+			if(!empty($this->get['reset']))
+			{
+				// Reset cart
+				$this->resetCart();
+				include_once 'e_sitelink.php';
+				$sl = new vstore_sitelink();
+				$msg = $sl->storeCart();
+				ob_clean();
+				$js = e107::getJshelper();
+				$js->_reset();
+				$js->addTextResponse('ok '.$msg)->sendResponse();
+				exit;
+			}
+		
+
+			if(!empty($this->get['refresh']))
+			{
+				// Refresh cart menu
+				include_once 'e_sitelink.php';
+				$sl = new vstore_sitelink();
+				$msg = $sl->storeCart();
+				ob_clean();
+				$js = e107::getJshelper();
+				$js->_reset();
+				$js->addTextResponse('ok '.$msg)->sendResponse();
+				exit;
+			}
+
+			// In case that none of the above has handled the ajax request
+			// (which shouldn't happen) just exit
+			exit;
+		}
+
+	}
+
+
+	/**
+	 * Handle & process all non-ajax requests
+	 *
+	 * @return void
+	 */
 	private function process()
 	{
 
@@ -1065,7 +1145,6 @@ class vstore
 		{
 			$this->resetCart();
 		}
-
 
 		if(!empty($this->post['gateway']))
 		{
@@ -1295,36 +1374,36 @@ class vstore
 
 		$ns = e107::getRender();
 
-		if($this->get['add'])
-		{
-			if(e_AJAX_REQUEST)
-			{
-				$js = e107::getJshelper();
-				$js->_reset();
-				$itemid = $this->get['add'];
-				$itemvars = $this->get['itemvar'];
-				if (!$this->addToCart($itemid, $itemvars))
-				{
-					$msg = e107::getMessage()->render('vstore');
-					ob_clean();
-					$js->addTextResponse($msg)->sendResponse();
-					exit;
-				}
-				else
-				{
-					$sl = new vstore_sitelink();
-					$msg = $sl->storeCart();
-				}
-				ob_clean();
-				$js->addTextResponse('ok '.$msg)->sendResponse();
-				exit;
-			}
-			$bread = $this->breadcrumb();
-			$text = $this->cartView();
-			$text = e107::getMessage()->render('vstore') . $text;
-			$ns->tablerender($this->captionBase, $bread.$text, 'vstore-cart-view');
-			return null;
-		}
+		// if($this->get['add'])
+		// {
+		// 	if(e_AJAX_REQUEST)
+		// 	{
+		// 		$js = e107::getJshelper();
+		// 		$js->_reset();
+		// 		$itemid = $this->get['add'];
+		// 		$itemvars = $this->get['itemvar'];
+		// 		if (!$this->addToCart($itemid, $itemvars))
+		// 		{
+		// 			$msg = e107::getMessage()->render('vstore');
+		// 			ob_clean();
+		// 			$js->addTextResponse($msg)->sendResponse();
+		// 			exit;
+		// 		}
+		// 		else
+		// 		{
+		// 			$sl = new vstore_sitelink();
+		// 			$msg = $sl->storeCart();
+		// 		}
+		// 		ob_clean();
+		// 		$js->addTextResponse('ok '.$msg)->sendResponse();
+		// 		exit;
+		// 	}
+		// 	$bread = $this->breadcrumb();
+		// 	$text = $this->cartView();
+		// 	$text = e107::getMessage()->render('vstore') . $text;
+		// 	$ns->tablerender($this->captionBase, $bread.$text, 'vstore-cart-view');
+		// 	return null;
+		// }
 
 		if (!empty($this->get['download']))
 		{
@@ -1335,34 +1414,34 @@ class vstore
 			}
 		}
 		
-		if(!empty($this->get['reset']))
-		{
-			if(e_AJAX_REQUEST)
-			{
-				$this->resetCart();
-				$sl = new vstore_sitelink();
-				$msg = $sl->storeCart();
-				ob_clean();
-				$js = e107::getJshelper();
-				$js->_reset();
-				$js->addTextResponse('ok '.$msg)->sendResponse();
-				exit;
-			}
-		}
+		// if(!empty($this->get['reset']))
+		// {
+		// 	if(e_AJAX_REQUEST)
+		// 	{
+		// 		$this->resetCart();
+		// 		$sl = new vstore_sitelink();
+		// 		$msg = $sl->storeCart();
+		// 		ob_clean();
+		// 		$js = e107::getJshelper();
+		// 		$js->_reset();
+		// 		$js->addTextResponse('ok '.$msg)->sendResponse();
+		// 		exit;
+		// 	}
+		// }
 		
-		if(!empty($this->get['refresh']))
-		{
-			if(e_AJAX_REQUEST)
-			{
-				$sl = new vstore_sitelink();
-				$msg = $sl->storeCart();
-				ob_clean();
-				$js = e107::getJshelper();
-				$js->_reset();
-				$js->addTextResponse('ok '.$msg)->sendResponse();
-				exit;
-			}
-		}
+		// if(!empty($this->get['refresh']))
+		// {
+		// 	if(e_AJAX_REQUEST)
+		// 	{
+		// 		$sl = new vstore_sitelink();
+		// 		$msg = $sl->storeCart();
+		// 		ob_clean();
+		// 		$js = e107::getJshelper();
+		// 		$js->_reset();
+		// 		$js->addTextResponse('ok '.$msg)->sendResponse();
+		// 		exit;
+		// 	}
+		// }
 
 
 		if($this->getMode() == 'return')
@@ -2562,6 +2641,13 @@ class vstore
 		return array_combine(explode(',', $k), explode(',', $v));
 	}
 
+	/**
+	 * Get the current inventory of the given item / itemvars combination
+	 *
+	 * @param int $itemid
+	 * @param array/boolean $itemvars
+	 * @return int
+	 */
 	private function getItemInventory($itemid, $itemvars=false)
 	{
 
@@ -2606,7 +2692,7 @@ class vstore
 		}
 		else
 		{
-			$inventory = (int) $sql->retrieve('vstore_items', 'item_inventory', 'cart_item = '.intval($id));
+			$inventory = (int) $sql->retrieve('vstore_items', 'item_inventory', 'item_id = '.intval($itemid));
 			if ($inventory < 0){
 				return 9999999;
 			}

--- a/vstore.php
+++ b/vstore.php
@@ -22,6 +22,15 @@ e107::js('settings', array('vstore' =>
 	)
 ));
 
+
+if (!empty($vstore_prefs['custom_css']))
+{
+	// Add any custom css to the page
+	e107::css('inline', "
+	/* vstore custom css */
+	" . $vstore_prefs['custom_css']);
+}
+
 $vstore = e107::getSingleton('vstore',e_PLUGIN.'vstore/vstore.class.php');
 $vstore->init();
 require_once(HEADERF);

--- a/vstore_menu.php
+++ b/vstore_menu.php
@@ -20,6 +20,13 @@ e107::js('settings', array('vstore' =>
 	)
 ));
 
+if (!empty($vstore_prefs['custom_css']))
+{
+	// Add any custom css to the page
+	e107::css('inline', "
+	/* vstore custom css */
+	" . $vstore_prefs['custom_css']);
+}
 
 $category = 1;  //TODO e_menu config.
 $caption = "Products";


### PR DESCRIPTION
**Custom-CSS**:
Added new pref which enables the user to add some custom css settings in the preferences of the shop without the need to edit any sourcecode files.

**Reorganized Ajax**:
Moved all ajax request related code from vstore::render() to a dedicated function vstore::process_ajax() which is executed before the normal vstore::process() function. This makes sure, that not more code is executed during an ajax request as needed.

**Fixed inventory issue**
There was an issue in the vstore::getItemInventory() resulting in the wrong (0) number of items in the inventory.

**Documentation**
Added some documentation to the methods of class vstore.

**Code cleanup** 
Removed certain commented code fragments our of vstore.class.php

**Fix for price issue**
There was an issue related to the item variations. The normal price was used and displayed instead of the updated price depending on the selected variations.

**fixed typo in sc_order_items()**
There was a typo in that function, preventing the customer emails to be send.

**check & fix category sef strings**
check if a "proposed" sef string is already in use by a different category. If so, append a counter string to the end of the sef string an check again until a sef string is found, that is not in use.
e.g. sef "cat1" is already in use, the function will check if "cat1-2" is available and if so, returns this sef string. If not, it will check "cat1-3", "cat1-4", etc. until it finds a free sef string with that pattern and returns it.