### PR TITLE
Implemented a order summary and confirmation page

### DIFF
--- a/e_url.php
+++ b/e_url.php
@@ -47,6 +47,13 @@ class vstore_url // plugin-folder + '_url'
 			'sef'			=>  '{alias}/checkout/',
 		);
 
+		
+		$config['confirm'] = array(
+			'regex'			=> '^{alias}/confirm/?$',
+			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=confirm',
+			'sef'			=>  '{alias}/confirm/',
+		);
+
 
 		$config['addtocart'] = array(
 			'regex'			=> '^{alias}/cart/add/([\d]*)$',

--- a/js/vstore.js
+++ b/js/vstore.js
@@ -232,6 +232,26 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 			});
 		}
 	};
+
+
+
+	/**
+	 * add active class to selected payment type
+	 */
+	e107.behaviors.vstoreSetGateway = {
+		attach: function (context, settings)
+		{
+			$(context).find('.vstore-gateway-radio').once('vstore-set-gateway').each(function (e)
+			{
+
+				$(this).change(function(){
+					$(".vstore-gateway").removeClass("active");
+					$(this).parent().addClass("active");
+				});
+			});
+		}
+	}
+
 })(jQuery);
 
 /** 

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -2112,10 +2112,11 @@ class vstore
 		    'order_e107_user'     => USERID,
 		    'order_cust_id'       => '',
 			'order_status'        => 'N' // New
-		 );
+		);
 
-		 $insert['order_items'] = json_encode($items, JSON_PRETTY_PRINT);
+		$insert['order_items'] = json_encode($items, JSON_PRETTY_PRINT);
 
+		unset($shippingData['additional']); // remove temporary data before save
 		foreach($shippingData as $fld=>$val)
 		{
 			$insert[$fld]    = $val;


### PR DESCRIPTION
**Order summary & confirmation**
German online shops have to comply to several rules. One rule is to display a summary of the items to order, the shipping information and payment method right before confirming the order. Only after confirming the order by clicking on a button (that has to have a specific title "Buy" or "Buy now!" (in german "Kaufen" oder "Jetzt Kaufen")), the customer will forwared to the selected payment gateway or in case of bank transfer, he receives the account information. 
