### PR TITLE
Bootstrap 4 compatibility fixes; Downloads fixed

### DIFF
--- a/admin_config.php
+++ b/admin_config.php
@@ -869,7 +869,9 @@ Region 	region
 			'admin_categories_perpage'	=> array('title'=> 'Categories per page', 'tab'=>3, 'type'=>'number', 'help'=>''),
 
 			'additional_fields'         => array('title'=>'Additional Fields', 'tab'=>4, 'type'=>'method'),
-			'admin_confirm_order'		=> array('title'=> 'Confirm order', 'tab'=>4, 'type'=>'bool', 'help'=>'If ON, the customer has to confirm his order after selecting the payment method on the checkout page!'),
+			
+			// Not used anymore, because of the redisigned checkout process (Summary and order confirmation page)
+			//'admin_confirm_order'		=> array('title'=> 'Confirm order', 'tab'=>4, 'type'=>'bool', 'help'=>'If ON, the customer has to confirm his order after selecting the payment method on the checkout page!'),
 
 			'custom_css'	            => array('title'=> 'Custom CSS', 'tab'=>5, 'type' => 'textarea', 'data' => 'str', 'width' => '100%', 'readParms' => '', 'writeParms' => array('cols'=> 80, 'rows' => 10, 'size'=>'block-level'), 'help'=>'Use this field to enter any vstore related custom css, without the need to edit any source files.'),
 		);
@@ -970,8 +972,8 @@ class vstore_cart_form_ui extends e_admin_form_ui
 			$text .= "
 				<tr>
 					<td>".$this->flipswitch('additional_fields['.$i.'][active]', $activeVal, null, array('switch'=>'small', 'title' => LAN_ACTIVE))."</td>
-					<td><span class='input-group'>".$this->text('additional_fields['.$i.'][caption]['.e_LANGUAGE.']', $capVal, 30, array('placeholder'=>LAN_CAPTION, 'size'=>'block-level')).$post."</span></td>
-					<td><span class='input-group'>".$this->text('additional_fields['.$i.'][placeholder]['.e_LANGUAGE.']',$placeholderVal, 30, array('placeholder'=>"Placeholder", 'size'=>'block-level')).$post."</span></td>
+					<td><span class='input-group'>".$this->text('additional_fields['.$i.'][caption]['.e_LANGUAGE.']', $capVal, 250, array('placeholder'=>LAN_CAPTION, 'size'=>'block-level')).$post."</span></td>
+					<td><span class='input-group'>".$this->text('additional_fields['.$i.'][placeholder]['.e_LANGUAGE.']',$placeholderVal, 100, array('placeholder'=>"Placeholder", 'size'=>'block-level')).$post."</span></td>
 					<td>".$this->select('additional_fields['.$i.'][type]', $opts, $typeVal )."</td>
 					<td>".$this->flipswitch('additional_fields['.$i.'][required]', $reqVal, null, array('switch'=>'small', 'title' => 'Required'))."</td>
 				</tr>

--- a/e_sitelink.php
+++ b/e_sitelink.php
@@ -89,13 +89,19 @@ class vstore_sitelink // include plugin-folder in the name.
 		//TODO Move into class.
 
 e107::getDebug()->log($data);
-		$text = '<div id="vstore-cart-dropdown" class="dropdown-menu">';
+
+		$text = '';
+		if (!e_AJAX_REQUEST)
+		{
+			$text = '<div id="vstore-cart-dropdown" class="dropdown-menu">';
+		}
 
 		if(empty($data))
 		{
 			$text .= '<div id="vstore-cart-dropdown-empty" class="alert alert-info">Your cart is empty.';
-			$text .= ' <a class="alert-link" href="'.e107::url('vstore','index').'">Start Shopping</a>';
-			$text .= '	</div></div>';
+			$text .= '<br/>  <a class="alert-link" href="'.e107::url('vstore','index').'">Start Shopping</a>';
+			$text .= '</div>';
+			if (!e_AJAX_REQUEST) $text .= '</div>';
 
 			return $text;
 		}
@@ -150,14 +156,15 @@ e107::getDebug()->log($data);
 
 						<li class="media text-right"><h4>Total: '.$sc->sc_cart_currency_symbol().' '.number_format($total,2).'</h4></li>
                             </ul>
-						<div id="vstore-item-count" class="hidden">'.$itemcount.'</div>
+						<input type="hidden" id="vstore-item-count" value="'.$itemcount.'"/>
                     </div>
 
 					<div>
 						 <a class="btn btn-block btn-danger" href="#" onclick="vstoreCartReset()"><i class="fa fa-trash-o" aria-hidden="true"></i> Clear cart</a>
 						 <a class="btn btn-block btn-primary col-xs-6" href="'.e107::url('vstore','cart').'"><i class="fa fa-shopping-cart" aria-hidden="true"></i> Checkout</a>
-					</div>
-				</div>			';
+					</div>';
+			if (!e_AJAX_REQUEST) $text .= '</div>';
+					
 
 		return $text;
 

--- a/e_url.php
+++ b/e_url.php
@@ -22,9 +22,9 @@ class vstore_url // plugin-folder + '_url'
 		$config = array();
 
 		$config['download'] = array(
-			'regex'			=> '^{alias}\/download/([\d]*)$',
+			'regex'			=> '^{alias}\/dl/([\d]*)$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?download=$1&',
-			'sef'			=> '{alias}/download/{item_id}'
+			'sef'			=> '{alias}/dl/{item_id}'
 		);
 		
 		$config['cancel'] = array(

--- a/e_url.php
+++ b/e_url.php
@@ -22,9 +22,9 @@ class vstore_url // plugin-folder + '_url'
 		$config = array();
 
 		$config['download'] = array(
-			'regex'			=> '^{alias}\/dl/([\d]*)$',
+			'regex'			=> '^{alias}\/request/([\d]*)$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?download=$1&',
-			'sef'			=> '{alias}/dl/{item_id}'
+			'sef'			=> '{alias}/request/{item_id}'
 		);
 		
 		$config['cancel'] = array(

--- a/js/vstore.js
+++ b/js/vstore.js
@@ -157,15 +157,23 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 						if (msg.substr(0, 2) == 'ok')
 						{
 							// if ok, update cart menu with new content
-							msg = msg.substr(2);
-							$('#vstore-cart-dropdown').replaceWith(msg);
-							var itemcount = $('#vstore-item-count').text();
+							msg = $.trim(msg.substr(2));
+							$('#vstore-cart-dropdown').html(msg);
+							var itemcount = $('#vstore-item-count').val();
 							if (itemcount <= 0) itemcount = 0;
-							$('#vstore-cart-icon .badge').html(itemcount);
+							if ($('#vstore-cart-icon .badge').length>0)
+							{
+								$('#vstore-cart-icon .badge').html(itemcount);
+							}
+							else if ($('#vstore-cart-icon .badge-pill').length>0)
+							{
+								$('#vstore-cart-icon .badge-pill').html(itemcount);
+							}
 							return;
 						}
 						// Print our any (error) message 
-						$('#uiAlert').html(msg);
+						// $('#uiAlert').html(msg);
+						vstorePrintMessage(msg);
 
 					});
 				});
@@ -184,7 +192,7 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 			{
 				$(this).change(function(e){
 					var itemid = $(this).data('id');
-					var baseprice = parseFloat($('.vstore-item-baseprice-'+itemid).text());
+					var baseprice = parseFloat($('.vstore-item-baseprice-'+itemid).val());
 					var varprice = baseprice;
 					var itemvars = [];
 
@@ -270,8 +278,15 @@ function vstoreCartReset()
 		{
 			// if ok, update cart menu with new content
 			msg = msg.substr(2);
-			$('#vstore-cart-dropdown').replaceWith(msg);
-			$('#vstore-cart-icon .badge').html(0);
+			$('#vstore-cart-dropdown').html(msg);
+			if ($('#vstore-cart-icon .badge').length>0)
+			{
+				$('#vstore-cart-icon .badge').html(0);
+			}
+			else if ($('#vstore-cart-icon .badge-pill').length>0)
+			{
+				$('#vstore-cart-icon .badge-pill').html(0);
+			}
 			return;
 		}
 	});
@@ -294,10 +309,17 @@ function vstoreCartRefresh()
 		{
 			// if ok, update cart menu with new content
 			msg = msg.substr(2);
-			$('#vstore-cart-dropdown').replaceWith(msg);
-			var itemcount = $('#vstore-item-count').text();
+			$('#vstore-cart-dropdown').html(msg);
+			var itemcount = $('#vstore-item-count').val();
 			if (itemcount <= 0) itemcount = 0;
-			$('#vstore-cart-icon .badge').html(itemcount);
+			if ($('#vstore-cart-icon .badge').length>0)
+			{
+				$('#vstore-cart-icon .badge').html(itemcount);
+			}
+			else if ($('#vstore-cart-icon .badge-pill').length>0)
+			{
+				$('#vstore-cart-icon .badge-pill').html(itemcount);
+			}
 			return;
 		}
 	});
@@ -358,4 +380,18 @@ function vstoreCheckInventory(itemid, itemvars)
 	}
 	return false;
 
+}
+
+function vstorePrintMessage(msg)
+{
+	if ($('#uiAlert').length > 0)
+	{	
+		$('#uiAlert').html(msg);
+	}
+	else
+	{
+		$('#breadcrumb').after('<div id="uiAlert">' + msg + '</div>');	
+	}
+	$('.s-message.fade').removeClass('fade');
+	$('.notifications.center > div').css('width', '50%');	
 }

--- a/templates/vstore_template.php
+++ b/templates/vstore_template.php
@@ -162,3 +162,32 @@ $VSTORE_WRAPPER['item']['ITEM_PIC: w=200&h=200&crop=1&item=5&link=1&class=thumbn
 $VSTORE_WRAPPER['item']['ITEM_PIC: w=200&h=200&crop=1&item=6&link=1&class=thumbnail img-responsive'] = "<div class='col-xs-3'><p>{---}</p></div>";
 $VSTORE_WRAPPER['item']['ITEM_PIC: w=200&h=200&crop=1&item=7&link=1&class=thumbnail img-responsive'] = "<div class='col-xs-3'><p>{---}</p></div>";
 
+$VSTORE_TEMPLATE['orderconfirm'] = '
+		<h3>Summary</h3>
+		<div class="row">
+			<div class="col-12 col-xs-12 col-sm-6 col-md-6">
+				<h4>Shipping address</h4>
+
+				<p>{ORDER_SHIP_FIRSTNAME} {ORDER_SHIP_LASTNAME}</p>
+				<p>{ORDER_SHIP_COMPANY}</p>
+				<p>{ORDER_SHIP_ADDRESS}</p>
+				<p>{ORDER_SHIP_CITY}, {ORDER_SHIP_STATE} {ORDER_SHIP_ZIP}</p>
+				<p>{ORDER_SHIP_COUNTRY}</p>
+				<br />
+				<h4>Selected payment method</h4>
+				<p>{ORDER_GATEWAY_ICON} {ORDER_GATEWAY_TITLE}</p>
+			</div>
+
+			<div class="col-6 col-xs-12 col-sm-6 col-md-6">
+				<h4>Items</h4>
+				{ORDER_ITEMS}
+			</div>
+		</div>
+		<hr />
+		<div class="row">
+			<div class="col-12 col-xs-12">
+				<a class="btn btn-default btn-secondary vstore-btn-back-confirm" href="{ORDER_CHECKOUT_URL}">&laquo; Back</a>
+				<button class="btn btn-primary vstore-btn-buy-now pull-right float-right" type="submit" name="mode" value="confirm">{ORDER_GATEWAY_ICON: size=1x} Buy now!</button>
+			</div>
+		</div>
+		';

--- a/templates/vstore_template.php
+++ b/templates/vstore_template.php
@@ -27,12 +27,12 @@ $VSTORE_TEMPLATE['list']['item']    =  '
 						                            <!--
 						                            <div class="ratings">
 						                                <p class="pull-right">15 reviews</p>
-						                                <p>
-						                                    <span class="glyphicon glyphicon-star"></span>
-						                                    <span class="glyphicon glyphicon-star"></span>
-						                                    <span class="glyphicon glyphicon-star"></span>
-						                                    <span class="glyphicon glyphicon-star"></span>
-						                                    <span class="glyphicon glyphicon-star"></span>
+														<p>
+															<i class="fa fa-star"></i>
+															<i class="fa fa-star"></i>
+															<i class="fa fa-star"></i>
+															<i class="fa fa-star"></i>
+															<i class="fa fa-star"></i>
 						                                </p>
 						                            </div>
 						                            -->

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -28,7 +28,8 @@ class vstore_plugin_shortcodes extends e_shortcode
 	{
 	 	$this->vpref = e107::pref('vstore');	
 				
-		$this->symbols = array('USD'=>'$','EUR'=>'€','CAN'=>'$','GBP'=>'£', "BTC"=> "<i class='fa fa-btc'></i>");
+		//$this->symbols = array('USD'=>'$','EUR'=>'€','CAN'=>'$','GBP'=>'£', "BTC"=> "<i class='fa fa-btc'></i>");
+		$this->symbols = array('USD'=>'$','EUR'=>'€','CAN'=>'$','GBP'=>'£', "BTC"=> e107::getParser()->toGlyph('fa-btc'));
 		$currency = !empty($this->vpref['currency']) ? $this->vpref['currency'] : 'USD';
 
 		$this->curSymbol = vartrue($this->symbols[$currency],'$');
@@ -692,19 +693,11 @@ class vstore_plugin_shortcodes extends e_shortcode
 		{
 			return "<a href='#' class='btn-out-of-stock ".$classo."'".$itemid.">".$this->captionOutOfStock."</a>";
 		}
-		// if(empty($this->var['item_inventory']))
-		// {
-		// 	return "<a href='#' class='btn-out-of-stock ".$classo."'".$itemid.">".$this->captionOutOfStock."</a>";
-		// }
 
-	
-		// $url = ($this->var['item_price'] == '0.00' || empty($this->var['item_inventory'])) ? $this->sc_item_url() :e107::url('vstore', 'addtocart', $this->var);
-		// $label =  ($this->var['item_price'] == '0.00' || empty($this->var['item_inventory'])) ? LAN_READ_MORE : 'Add to cart';
 		$label =  ($this->var['item_price'] == '0.00' || !$inStock) ? LAN_READ_MORE : 'Add to cart';
 
 
-		// return '<a class="'.$class.'" '.$itemid.' href="'.$url.'"><span class="glyphicon glyphicon-shopping-cart"></span> '.$label.'</a>';
-		return '<a class="'.$class.'" '.$itemid.' href="#"><span class="glyphicon glyphicon-shopping-cart"></span> '.$label.'</a>';
+		return '<a class="'.$class.'" '.$itemid.' href="#">'.e107::getParser()->toGlyph('fa-shopping-cart').' '.$label.'</a>';
 	}
 
 
@@ -775,8 +768,9 @@ class vstore_plugin_shortcodes extends e_shortcode
 	
 	function sc_cart_removebutton($parm=null)
 	{
+
 		return '<button type="submit" name="cartRemove['.$this->var['cart_id'].']" class="btn btn-default btn-secondary" title="Remove">
-			<span class="fa fa-trash"></span></button>';
+			'.e107::getParser()->toGlyph('fa-trash').'</button>';
 		
 	}
 	
@@ -793,7 +787,7 @@ class vstore_plugin_shortcodes extends e_shortcode
 	function sc_cart_checkout_button()
 	{
 		$text = '<a href="'.e107::url('vstore','checkout').'" id="cart-checkout"  class="btn btn-success">
-		                            Checkout <span class="glyphicon glyphicon-play"></span>
+		                            Checkout '.e107::getParser()->toGlyph('fa-play').'
 		                        </a>
 		                        <button id="cart-qty-submit" style="display:none" type="submit" class="btn btn-warning">Re-Calculate</button>
 
@@ -812,7 +806,7 @@ class vstore_plugin_shortcodes extends e_shortcode
 		
 		return '
 		<a href="'.$link.'" class="btn btn-default btn-secondary">
-			<span class="glyphicon glyphicon-shopping-cart"></span> Continue Shopping
+		'.e107::getParser()->toGlyph('fa-shopping-cart').' Continue Shopping
 		</a>';
 	}
 

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -473,11 +473,6 @@ class vstore_plugin_shortcodes extends e_shortcode
 	
 	function sc_item_brand_url($parm=null)
 	{
-		// if(!empty($this->var['cat_sef']))
-		// {
-		// 	return $this->var['item_link'];
-		// }
-	
 		return e107::url('vstore', 'category', array('cat_sef' => $this->var['cat_sef']));
 	}
 
@@ -634,18 +629,26 @@ class vstore_plugin_shortcodes extends e_shortcode
 		}
 
 
-		$qry = 'SELECT media_id,media_name FROM #core_media WHERE media_id IN ('.implode(',',$id).') ORDER BY media_name ';
-		$files = e107::getDb()->retrieve($qry,true);
+		// $qry = 'SELECT media_id,media_name FROM #core_media WHERE media_id IN ('.implode(',',$id).') ORDER BY media_name ';
+		// $files = e107::getDb()->retrieve($qry,true);
 
-		$tp = e107::getParser();
+		// $tp = e107::getParser();
 		
-		$text = '<ul>';
-		foreach($files as $i)
-		{
-			$bb = '[file='.$i['media_id'].']'.$i['media_name'].'[/file]';
-			$text .= '<li>'.$tp->toHtml($bb,true).'</li>';
+		// $text = '<ul>';
+		// foreach($files as $i)
+		// {
+		// 	// $bb = '[file='.$i['media_id'].']'.$i['media_name'].'[/file]';
+		// 	// $text .= '<li>'.$tp->toHtml($bb,true).'</li>';
+		// }
+		
+		foreach ($ival as $item) {
+			if(!empty($item['path']) && !empty($item['id']))
+			{
+				$linktext = $item['name'];
+				$text .= '<li><a href="'.e107::url('vstore', 'download', array('item_id' => $item['id']), array('mode'=>'full')).'">'.$linktext.'</a></li>';
+			}
 		}
-		
+
 		$text .= '</ul>';
 		
 		return $text;
@@ -1533,15 +1536,18 @@ class vstore
 
 		$ns = e107::getRender();
 
+
 		if (!empty($this->get['download']))
 		{
 			if (!$this->downloadFile($this->get['download']))
 			{
-				echo e107::getMessage()->render('vstore');
+				$bread = $this->breadcrumb();
+				$msg = e107::getMessage()->render('vstore');
+	
+				$ns->tablerender($this->captionBase, $bread.$msg, 'vstore-download-failed');
 				return null;
 			}
 		}
-
 		
 		if($this->getMode() == 'return')
 		{
@@ -1549,8 +1555,6 @@ class vstore
 			$bread = $this->breadcrumb();
 			$text = $this->checkoutComplete();
 			$msg = e107::getMessage()->render('vstore');
-
-			//TODO Check for digital download purchase and render download button.
 
 			$ns->tablerender($this->captionBase, $bread.$msg.$text, 'vstore-cart-complete');
 			return null;
@@ -1673,7 +1677,14 @@ class vstore
 
 		if (!isset($this->get['mode']))
 		{
-			$array[] = array('url'=> e107::url('vstore','index'), 'text'=>$this->captionCategories);
+			if (!empty($this->get['download']))
+			{
+				$array[] = array('url'=> e107::url('vstore','index'), 'text'=>'Download');
+			}
+			else
+			{
+				$array[] = array('url'=> e107::url('vstore','index'), 'text'=>$this->captionCategories);
+			}
 		}
 		
 		if($this->get['cat'] || $this->get['item'])

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -661,7 +661,7 @@ class vstore_plugin_shortcodes extends e_shortcode
 		{
 			$price = $varprice;
 		}
-		return $this->currency.$this->curSymbol.' <span class="vstore-item-price-'.$itemid.'">'.number_format($price, 2).'</span><span class="hidden vstore-item-baseprice-'.$itemid.'">'.$baseprice.'</span>'; 
+		return $this->currency.$this->curSymbol.' <span class="vstore-item-price-'.$itemid.'">'.number_format($price, 2).'</span><input type="hidden" class="vstore-item-baseprice-'.$itemid.'" value="'.$baseprice.'"/>'; 
 		// return ($this->var['item_price'] == '0.00') ? "" : $this->currency.$this->curSymbol.' '.$this->var['item_price'];	
 	}	
 	
@@ -670,7 +670,7 @@ class vstore_plugin_shortcodes extends e_shortcode
 	{
 
 		$class = empty($parm['class']) ? 'btn btn-success vstore-add' : $parm['class'];
-		$classo = empty($parm['class0']) ? 'btn btn-default disabled vstore-add' : $parm['class0'];
+		$classo = empty($parm['class0']) ? 'btn btn-default btn-secondary disabled vstore-add' : $parm['class0'];
 		$itemid = ' data-vstore-item="'.varset($this->var['item_id'], 0).'"';
 
 		if (!in_array('vstore-add', explode(' ', $class)))
@@ -775,7 +775,7 @@ class vstore_plugin_shortcodes extends e_shortcode
 	
 	function sc_cart_removebutton($parm=null)
 	{
-		return '<button type="submit" name="cartRemove['.$this->var['cart_id'].']" class="btn btn-default" title="Remove">
+		return '<button type="submit" name="cartRemove['.$this->var['cart_id'].']" class="btn btn-default btn-secondary" title="Remove">
 			<span class="fa fa-trash"></span></button>';
 		
 	}
@@ -811,7 +811,7 @@ class vstore_plugin_shortcodes extends e_shortcode
 		$link = e107::url('vstore','index');
 		
 		return '
-		<a href="'.$link.'" class="btn btn-default">
+		<a href="'.$link.'" class="btn btn-default btn-secondary">
 			<span class="glyphicon glyphicon-shopping-cart"></span> Continue Shopping
 		</a>';
 	}
@@ -1253,14 +1253,14 @@ class vstore
 
 		$text = '<h3>Shipping Details</h3>
 			    			<div class="row">
-			    				<div class="col-xs-6 col-sm-6 col-md-6">
+			    				<div class="col-6 col-xs-6 col-sm-6 col-md-6">
 			    					<div class="form-group">
 			    					 <label for="firstname">First Name</label>
 			    					'.$frm->text('firstname', $this->post['firstname'], 100, array('placeholder'=>'First Name', 'required'=>1)).'
 
 			    					</div>
 			    				</div>
-			    				<div class="col-xs-6 col-sm-6 col-md-6">
+			    				<div class="col-6 col-xs-6 col-sm-6 col-md-6">
 			    					<div class="form-group">
 			    					<label for="lastname">Last Name</label>
 			    						'.$frm->text('lastname', $this->post['lastname'], 100, array('placeholder'=>'Last Name', 'required'=>1)).'
@@ -1279,13 +1279,13 @@ class vstore
 			    			</div>
 
 			    			<div class="row">
-			    				<div class="col-xs-6 col-sm-6 col-md-6">
+			    				<div class="col-6 col-xs-6 col-sm-6 col-md-6">
 			    					<div class="form-group">
 			    					<label for="city">Town/City</label>
 			    						'.$frm->text('city', $this->post['city'], 100, array('placeholder'=>'Town/City', 'required'=>1)).'
 			    					</div>
 			    				</div>
-			    				<div class="col-xs-6 col-sm-6 col-md-6">
+			    				<div class="col-6 col-xs-6 col-sm-6 col-md-6">
 			    					<div class="form-group">
 			    					<label for="state">State/Region</label>
 			    						'.$frm->text('state', $this->post['state'], 100, array('placeholder'=>'State/Region', 'required'=>1)).'
@@ -1295,13 +1295,13 @@ class vstore
 
 
 							<div class="row">
-			    				<div class="col-xs-6 col-sm-6 col-md-6">
+			    				<div class="col-6 col-xs-6 col-sm-6 col-md-6">
 			    					<div class="form-group">
 			    					<label for="zip">Zip/Postcode</label>
 			    						'.$frm->text('zip', $this->post['zip'], 15, array('placeholder'=>'Zip/Postcode', 'required'=>1)).'
 			    					</div>
 			    				</div>
-			    				<div class="col-xs-6 col-sm-6 col-md-6">
+			    				<div class="col-6 col-xs-6 col-sm-6 col-md-6">
 			    					<div class="form-group">
 			    					<label for="country">Country</label>
 			    						'.$frm->country('country', $this->post['country'], array('placeholder'=>'Select Country...', 'required'=>1)).'
@@ -1310,13 +1310,13 @@ class vstore
 			    			</div>
 
 						<div class="row">
-			    				<div class="col-xs-6 col-sm-6 col-md-6">
+			    				<div class="col-6 col-xs-6 col-sm-6 col-md-6">
 			    					<div class="form-group">
 			    					<label for="email">Email address</label>
 			    						'.$frm->email('email', $this->post['email'], 100, array('placeholder'=>'Email address', 'required'=>1)).'
 			    					</div>
 			    				</div>
-			    				<div class="col-xs-6 col-sm-6 col-md-6">
+			    				<div class="col-6 col-xs-6 col-sm-6 col-md-6">
 			    					<div class="form-group">
 			    					<label for="phone">Phone number</label>
 			    						'.$frm->text('phone', $this->post['phone'], 15, array('placeholder'=>'Phone number', 'required'=>1)).'
@@ -1324,10 +1324,10 @@ class vstore
 			    				</div>
 			    		</div>
 			    		<div class="row">
-			    		    <div class="col-md-12">
+			    		    <div class="col-12 col-md-12">
 								<div class="form-group">
 				                <label for="notes">Order Notes</label>
-				                    '.$frm->textarea('notes', $this->post['notes'], 4, null, array('placeholder'=>'Special notes for delivery.', 'required'=>0)).'
+				                    '.$frm->textarea('notes', $this->post['notes'], 4, null, array('placeholder'=>'Special notes for delivery.', 'required'=>0, 'size'=>'large')).'
 				                </div>
 			    			</div>
 						</div>
@@ -1351,6 +1351,7 @@ class vstore
 
 		if ($addFieldActive > 0)
 		{
+			$ns = e107::getParser();
 			// If any additional fields are enabled
 			// add active fields to form
 			$text .= '<br/><div class="row">';
@@ -1370,16 +1371,16 @@ class vstore
 						$field = '<div class="form-control">'.$frm->checkbox($fieldname, 1, $this->post[$fieldname], array('required'=>($v['required'] ? 1 : 0)));
 						if (vartrue($v['placeholder']))
 						{
-							$field .= ' <span class="text-muted">&nbsp;'.$v['placeholder'][e_LANGUAGE].'</span>';
+							$field .= ' <span class="text-muted">&nbsp;'.$ns->toHTML($v['placeholder'][e_LANGUAGE]).'</span>';
 						}
 						$field .= '</div>';
 					}
 
 					// Bootstrap wrapper for control
 					$text .= '
-						<div class="'.($addFieldActive == 1 ? 'col-md-12' : 'col-xs-6 col-sm-6 col-md-6').'">
+						<div class="'.($addFieldActive == 1 ? 'col-12 col-md-12' : 'col-6 col-xs-6 col-sm-6 col-md-6').'">
 							<div class="form-group">
-								<label for="'.$fieldname.'">'.varset($v['caption'][e_LANGUAGE], 'Additional field '.$k).'</label>
+								<label for="'.$fieldname.'">'.$ns->toHTML(varset($v['caption'][e_LANGUAGE], 'Additional field '.$k)).'</label>
 								'.$field.'
 							</div>
 						</div>
@@ -1396,12 +1397,12 @@ class vstore
 		if(!USER)
 		{
 			$text .= '<div class="row">
-			    				<div class="col-xs-6 col-sm-6 col-md-6">
+			    				<div class="col-6 col-xs-6 col-sm-6 col-md-6">
 			    					<div class="form-group">
 			    						<input type="password" name="password" id="password" class="form-control input-sm" placeholder="Password">
 			    					</div>
 			    				</div>
-			    				<div class="col-xs-6 col-sm-6 col-md-6">
+			    				<div class="col-6 col-xs-6 col-sm-6 col-md-6">
 			    					<div class="form-group">
 			    						<input type="password" name="password_confirmation" id="password_confirmation" class="form-control input-sm" placeholder="Confirm Password">
 			    					</div>
@@ -1437,7 +1438,7 @@ class vstore
 		$text = '
 		<h3>Summary</h3>
 		<div class="row">
-			<div class="col-xs-12 col-sm-6 col-md-6">
+			<div class="col-12 col-xs-12 col-sm-6 col-md-6">
 				<h4>Shipping address</h4>';
 		
 		$text .= $shippingData['order_ship_firstname'] . ' ' . $shippingData['order_ship_lastname'] . '<br/>';
@@ -1451,7 +1452,7 @@ class vstore
 			<h4>Selected payment method</h4>
 			<p>' . $gatewayIcon . ' ' . $gatewayTitle . '</p>
 		</div>
-			<div class="col-xs-12 col-sm-6 col-md-6">
+			<div class="col-6 col-xs-12 col-sm-6 col-md-6">
 				<h4>Items</h4>';
 
 		$grandTotal = 0.0;
@@ -1477,8 +1478,8 @@ class vstore
 			$text .= '
 				<div class="row">
 				<p>
-					<div class="col-xs-8">'.$row['item_name'].$itemvar.'</div>
-					<div class="col-xs-4 text-right">'.$sc->getCurrencySymbol().number_format($subtotal, 2).'</div>
+					<div class="col-8 col-xs-8">'.$row['item_name'].$itemvar.'</div>
+					<div class="col-4 col-xs-4 text-right">'.$sc->getCurrencySymbol().number_format($subtotal, 2).'</div>
 				</p>
 				</div>';
 
@@ -1489,14 +1490,14 @@ class vstore
 		$text .= '
 				<div class="row" style="border-top:1px solid #ccc;margin-top: 6px;">
 				<p>
-					<div class="col-xs-8">Shipping</div>
-					<div class="col-xs-4 text-right">'.$sc->getCurrencySymbol().number_format($shippingTotal, 2).'</div>
+					<div class="col-8 col-xs-8">Shipping</div>
+					<div class="col-4 col-xs-4 text-right">'.$sc->getCurrencySymbol().number_format($shippingTotal, 2).'</div>
 				</p>
 				</div>
 				<div class="row" style="border-top:4px double #ccc;margin-top: 6px;">
 				<p>
-					<div class="col-xs-8"><b>Total</b></div>
-					<div class="col-xs-4 text-right"><b>'.$sc->getCurrencySymbol().number_format($grandTotal, 2).'</b></div>
+					<div class="col-8 col-xs-8"><b>Total</b></div>
+					<div class="col-4 col-xs-4 text-right"><b>'.$sc->getCurrencySymbol().number_format($grandTotal, 2).'</b></div>
 				</p>
 				</div>';
 
@@ -1505,9 +1506,9 @@ class vstore
 		</div>
 		<hr />
 		<div class="row">
-			<div class="col-xs-12">
-				<a class="btn btn-default vstore-btn-back-confirm col-xs-5" href="'.e107::url('vstore', 'checkout', 'sef').'">&laquo; Back</a>
-				<button class="btn btn-primary vstore-btn-buy-now col-xs-5 pull-right" type="submit" name="mode" value="confirm">'.$gatewayIconSmall.' Buy now!</button>
+			<div class="col-12 col-xs-12">
+				<a class="btn btn-default btn-secondary vstore-btn-back-confirm" href="'.e107::url('vstore', 'checkout', 'sef').'">&laquo; Back</a>
+				<button class="btn btn-primary vstore-btn-buy-now pull-right float-right" type="submit" name="mode" value="confirm">'.$gatewayIconSmall.' Buy now!</button>
 			</div>
 		</div>
 		
@@ -1784,8 +1785,8 @@ class vstore
 			{
 
 				$text .= "
-						<div class='col-md-4'>
-							<label class='btn btn-default btn-block btn-".$gateway." ".($curGateway == $gateway ? 'active' : '')." vstore-gateway'>
+						<div class='col-6 col-xs-6 col-sm-4'>
+							<label class='btn btn-default btn-light btn-block btn-".$gateway." ".($curGateway == $gateway ? 'active' : '')." vstore-gateway'>
 								<input type='radio' name='gateway' value='".$gateway."' style='display:none;' class='vstore-gateway-radio' required ".($curGateway == $gateway ? 'checked' : '').">
 								".$icon."
 								<h4>".$this->getGatewayTitle($gateway)."</h4>
@@ -1798,32 +1799,14 @@ class vstore
 
 			$text .= '<br/>
 			<div class="row">
-				<div class="col-xs-12">
-					<a class="btn btn-default vstore-btn-back-confirm col-xs-5" href="'.e107::url('vstore', 'cart', 'sef').'">&laquo; Back</a>
-					<button class="btn btn-primary vstore-btn-buy-now col-xs-5 pull-right" type="submit" name="mode" value="gateway">Continue &raquo;</button>
+				<div class="col-12 col-xs-12">
+					<a class="btn btn-default btn-secondary vstore-btn-back-confirm" href="'.e107::url('vstore', 'cart', 'sef').'">&laquo; Back</a>
+					<button class="btn btn-primary vstore-btn-buy-now pull-right float-right" type="submit" name="mode" value="gateway">Continue &raquo;</button>
 				</div>
 			</div>';
 
 			$text .= e107::getForm()->close();
 
-			// if (vartrue(e107::pref('vstore', 'admin_confirm_order')))
-			// {
-			// 	// If the user has to confirm the order
-			// 	$text .= '
-			// 	<script type="text/javascript">
-			// 	$(function(){
-			// 		$("#gateway-select").submit(function(e){
-			// 			if(!confirm("By clicking on OK you confirm that you order the content of the shopping cart for the shown cost!"))
-			// 			{
-			// 				e.preventDefault();
-			// 				return false;
-			// 			}
-			// 			return true;
-			// 		});
-			// 	});
-			// 	</script>
-			// 	';
-			// }
 
 			return $text;
 		}
@@ -1846,25 +1829,6 @@ class vstore
 		$text .= $this->renderConfirmOrder();
 
 		$text .= e107::getForm()->close();
-
-		// if (vartrue(e107::pref('vstore', 'admin_confirm_order')))
-		// {
-		// 	// If the user has to confirm the order
-		// 	$text .= '
-		// 	<script type="text/javascript">
-		// 	$(function(){
-		// 		$("#gateway-select").submit(function(e){
-		// 			if(!confirm("By clicking on OK you confirm that you order the content of the shopping cart for the shown cost!"))
-		// 			{
-		// 				e.preventDefault();
-		// 				return false;
-		// 			}
-		// 			return true;
-		// 		});
-		// 	});
-		// 	</script>
-		// 	';
-		// }
 
 		return $text;
 	}

--- a/vstore.php
+++ b/vstore.php
@@ -27,6 +27,12 @@ if (!empty($vstore_prefs['custom_css']))
 {
 	// Add any custom css to the page
 	e107::css('inline', "
+	/* Fix for Boostrap 4 */
+	.s-message.fade {
+		opacity: 1;
+		visibility: inherit;
+	}
+	
 	/* vstore custom css */
 	" . $vstore_prefs['custom_css']);
 }


### PR DESCRIPTION
**Bootstrap 4 compatibility**
- Several issues with Bootstrap 4 themes (e.g. Agency2) fixed
- Switched icons from glyphicons to fontawesome, because glyphicons are missing in Bootstrap 4

**Downloads**
- Switched links for the files list of a product, to use the vstore download function, to make sure that only "purchased" files are downloadable by the user.
- Fixed issue with the download url, as it invokes the download plugin in addition to the vstore download handler
- Fixed  also an issue with wrong download urls for the files mentioned in the  product details view in the Downlods (now Files) section. As this files  are not the files to purchase, there is no need to check if the item is  purchased.

**Order confirmation template**
Moved order confirmation page into a template.

