### PR TITLE
Invoices (PDF & Email), Guest orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+invoices/*.pdf

--- a/admin_config.php
+++ b/admin_config.php
@@ -44,6 +44,13 @@ class vstore_admin extends e_admin_dispatcher
 			'uipath' 		=> 'inc/admin_config_email_templates.php'
 		),
 		
+		'invoice'	=> array(
+			'controller' 	=> 'vstore_invoice_pref_ui',
+			'path' 			=> 'inc/admin_config_invoice.php',
+			'ui' 			=> 'vstore_invoice_pref_form_ui',
+			'uipath' 		=> 'inc/admin_config_invoice.php'
+		),
+		
 		'gateways'	=> array(
 			'controller' 	=> 'vstore_gateways_ui',
 			'path' 			=> 'inc/admin_config_gateways.php',
@@ -134,6 +141,8 @@ class vstore_admin extends e_admin_dispatcher
 		'main/prefs' 		=> array('caption'=> LAN_PREFS, 'perm' => 'P'),
 
 		'email/prefs' 		=> array('caption'=> 'Email Templates', 'perm' => 'P'),
+
+		'invoice/prefs' 	=> array('caption'=> 'Invoice settings', 'perm' => 'P'),
 
 		'gateways/prefs'	=> array('caption'=> "Payment Gateways", 'perm' => 'P'),
 

--- a/e_sitelink.php
+++ b/e_sitelink.php
@@ -79,7 +79,7 @@ class vstore_sitelink // include plugin-folder in the name.
 
 		$data = $vst->getCartData();
 		$cust = $vst->getCustomerData();
-		$data = $vst->prepareCheckoutData($data, false);
+		$data = $vst->prepareCheckoutData($data, false, true);
 
 		$isBusiness = !empty($cust['vat_id']);
 		$isLocal = (varset($cust['country'], e107::pref('vstore', 'tax_business_country')) == e107::pref('vstore', 'tax_business_country'));

--- a/e_url.php
+++ b/e_url.php
@@ -21,6 +21,18 @@ class vstore_url // plugin-folder + '_url'
 	{
 		$config = array();
 
+		$config['dashboard'] = array(
+			'regex'			=> '^{alias}\/my\/?([a-zA-Z]*)\/?\??',
+			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=dashboard&area=$1&',
+			'sef'			=> '{alias}/my/{dashboard}'
+		);
+
+		$config['dashboard_do'] = array(
+			'regex'			=> '^{alias}\/my\/?([a-zA-Z]*)\/?([a-zA-Z]*)\/?([\d]*)\/?$',
+			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=dashboard&area=$1&do=$2&id=$3',
+			'sef'			=> '{alias}/my/{dashboard}/{action}/{id}'
+		);
+
 		$config['invoice'] = array(
 			'regex'			=> '^{alias}\/invoice\/([\d]*)\/?$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?invoice=$1&',

--- a/e_url.php
+++ b/e_url.php
@@ -22,7 +22,7 @@ class vstore_url // plugin-folder + '_url'
 		$config = array();
 
 		$config['invoice'] = array(
-			'regex'			=> '^{alias}/invoice/([\d]*)$',
+			'regex'			=> '^{alias}\/invoice\/([\d]*)\/?$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?invoice=$1&',
 			'sef'			=> '{alias}/invoice/{order_invoice_nr}/'
 		);

--- a/e_url.php
+++ b/e_url.php
@@ -21,6 +21,12 @@ class vstore_url // plugin-folder + '_url'
 	{
 		$config = array();
 
+		$config['invoice'] = array(
+			'regex'			=> '^{alias}/invoice/([\d]*)$',
+			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?invoice=$1&',
+			'sef'			=> '{alias}/invoice/{order_invoice_nr}/'
+		);
+
 		$config['download'] = array(
 			'regex'			=> '^{alias}\/request/([\d]*)$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?download=$1&',

--- a/inc/admin_config_invoice.php
+++ b/inc/admin_config_invoice.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Adminarea module cart
+ */
+class vstore_invoice_pref_ui extends e_admin_ui
+{
+			
+		protected $pluginTitle		= 'Vstore';
+		protected $pluginName		= 'vstore';
+
+
+		// optional
+		// protected $preftabs = array('Settings', 'Template');
+
+
+		protected $prefs = array(
+			'invoice_title'        		=> array('title'=> 'Title', 'tab'=>0, 'type'=>'text', 'data' => 'str', 'writeParms'=>array('placeholder'=>'Title', 'default'=>'INVOICE'),'multilan'=>true, 'help' => 'Title of the invoice'),
+			'invoice_info_title'        => array('title'=> 'Information section caption', 'tab'=>0, 'type'=>'text', 'data' => 'str', 'writeParms'=>array('placeholder'=>'Information block title', 'default'=>'Information'),'multilan'=>true, 'help' => 'Title of the information block on the top right side of the invoice.'),
+			'invoice_subject'        	=> array('title'=> 'Subject', 'tab'=>0, 'type'=>'text', 'data' => 'str', 'writeParms'=>array('placeholder'=>'Subject', 'default'=>'This is the invoice for your order #{ORDER_DATA: order_ref} from {ORDER_DATA: order_date}'),'multilan'=>true, 'note'=>'This is rendered right above the items.'),
+			'invoice_nr_prefix'  		=> array('title'=> 'Invoice number prefix', 'tab'=>0, 'type'=>'text', 'data' => 'str', 'writeParms'=>array('placeholder'=>'IN', 'default'=>'IN', 'maxlength' => '5'), 'help' => 'Define the prefix for your invoice number. This will be rendered e.g. IN000012'),
+			'invoice_next_nr'  			=> array('title'=> 'Next invoice number', 'tab'=>0, 'type'=>'method', 'data' => 'int', 'writeParms'=>array('default'=>'1'), 'help' => 'This enables you to start at a given invoice number, or to step over a number. But it will ALWAYS be bigger than the last invoice number used!'),
+			'invoice_date_format'		=> array('title'=> 'Invoice date format', 'tab'=>0, 'type'=>'text', 'data' => 'str', 'writeParms'=>array('placeholder'=>'Dateformat used on invoices (date only)', 'default'=>'%m/%d/%Y'), 'help' => 'Date format (date only) used on onvoices. e.g. 05/02/2018'),
+			'invoice_payment_deadline'  => array('title'=> 'Default payment deadline (days)', 'tab'=>0, 'type'=>'number', 'data' => 'int', 'writeParms'=>array('default'=>'7'), 'help' => 'A notice will be added to the invoice, when the invoice should be paid latest.'),
+			'invoice_hint'        		=> array('title'=> 'Hint', 'tab'=>0, 'type' =>'method', 'data' => 'str', 'note' => 'This will be rendered on the invoice below the items and can be used to add some information on each invoice.'),
+			'invoice_finish_phrase'		=> array('title'=> 'Finishing phrase', 'tab'=>0, 'type' =>'method', 'data' => 'str', 'note' => 'This will be rendered on the invoice below the items and the hint.', 'writeParms' => array('placeholder' => 'Finishing phase', 'default' => 'Thanks for your business!<br><br><br>Yours faithfully<br><br>_______________________________________')),
+			'invoice_footer'        	=> array('title'=> 'Footer content', 'tab'=>0, 'type'=>'method', 'data' => 'json', 'writeParms'=>'', 'note' => 'These fields will be rendered on the bottom of each page.'),
+			
+			// 'invoice_template'         => array('title'=> "Invoice template", 'type'=>'method', 'tab' => 1, 'data' => 'str'),
+		);
+
+
+
+		// optional
+		public function init()
+		{
+
+			// $email_fields = array(
+			// 	'{ORDER_DATA: order_ref}'		=> 'The order reference number',
+			// 	'{ORDER_DATA: cust_firstname}'	=> 'The billing firstname',
+			// 	'{ORDER_DATA: cust_lastname}' 	=> 'The billing lastname',
+			// 	'{ORDER_DATA: cust_company}'	=> 'The billing company name',
+			// 	'{ORDER_DATA: cust_address}'	=> 'The billing street',
+			// 	'{ORDER_DATA: cust_city}'		=> 'The billing city',
+			// 	'{ORDER_DATA: cust_state}'		=> 'The billing state',
+			// 	'{ORDER_DATA: cust_zip}'		=> 'The billing zip code',
+			// 	'{ORDER_DATA: cust_country}'	=> 'The billing country',
+			// 	'{ORDER_DATA: ship_firstname}'	=> 'The shipping firstname',
+			// 	'{ORDER_DATA: ship_lastname}' 	=> 'The shipping lastname',
+			// 	'{ORDER_DATA: ship_company}'	=> 'The shipping company name',
+			// 	'{ORDER_DATA: ship_address}'	=> 'The shipping street',
+			// 	'{ORDER_DATA: ship_city}'		=> 'The shipping city',
+			// 	'{ORDER_DATA: ship_state}'		=> 'The shipping state',
+			// 	'{ORDER_DATA: ship_zip}'		=> 'The shipping zip code',
+			// 	'{ORDER_DATA: ship_country}'	=> 'The shipping country',
+			// 	'{ORDER_ITEMS}'					=> 'The ordered items',
+			// 	'{ORDER_PAYMENT_INSTRUCTIONS}' 	=> 'In case of payment method "bank transfer", the bank transfer details',
+			// 	'{ORDER_MERCHANT_INFO}'			=> 'Merchant name & adress',
+			// 	'{SENDER_NAME}'					=> 'Sender name es defined in the vstore prefs'
+			// );
+	
+			// foreach ($email_fields as $key => $value) {
+			// 	$field_notes[] = sprintf('<div>%s</div><div class="col-sm-offset-1">%s</div>', $key, $value);
+			// }
+	
+			// $text = '<div>'.$this->prefs['email_templates']['title'].'<br/><br/>Available fields<br/>';
+			// $text .= '<div class="small">'.implode("\n", $field_notes).'</div></div>';
+	
+			// $this->prefs['email_templates']['title'] = $text;
+			
+		}
+
+
+		
+		// public function customPage()
+		// {
+		// 	$ns = e107::getRender();
+		// 	$text = 'Hello World!';
+		// 	$ns->tablerender('Hello',$text);	
+			
+		// }
+	
+			
+}
+
+
+class vstore_invoice_pref_form_ui extends e_admin_form_ui
+{
+
+	public function init()
+	{
+
+        $js = "
+		$(function(){
+			$('.vstore-invoice-reset').click(function(){
+				var template = decodeURIComponent($(this).data('template'));
+
+				var id = 'invoice-template';
+				$('#'+id).val(template);
+				$(tinymce.get(id).getBody()).html(template);
+			});
+		});
+		";
+        e107::js('footer-inline', $js);
+        
+	}
+
+	function invoice_template($curVal, $mode)
+	{
+		$frm = e107::getForm();		
+
+		e107::wysiwyg(true);
+
+		$orig_templates = e107::getTemplate('vstore', 'vstore_invoice');
+		$orig_templates = $orig_templates['default'];
+
+		$text = '
+		<div class="row">
+			<div class="form-group">
+				<div class="text-right col-6 col-xs-6">
+					'.$this->button('', '<span class="fa fa-undo"></span> '. 'Reset template', 'action', '', array('data-template' => rawurlencode($orig_templates), 'class' => 'vstore-invoice-reset pull-right btn-sm', 'title' => 'Click & save to reset this template to the default template.')).'
+				</div>
+			</div>
+		</div>
+		<div class="row">
+			'.$this->textarea('invoice_template', $curVal, 10, 80, array('class' => 'tbox form-control input-block-level e-autoheight e-wysiwyg', 'size' => 'xxlarge')).'
+		</div>
+		';
+
+		return $text;
+		 		
+	}
+
+
+	function invoice_hint($curVal, $mode)
+	{
+		e107::wysiwyg(true);
+
+		return e107::getForm()->textarea('invoice_hint['.e_LANGUAGE.']', varsettrue($curVal[e_LANGUAGE], ''), 5, 80, array('class' => 'tbox form-control input-block-level e-autoheight e-wysiwyg'));
+	}
+
+	function invoice_finish_phrase($curVal, $mode)
+	{
+		e107::wysiwyg(true);
+
+		return e107::getForm()->textarea('invoice_finish_phrase', varsettrue($curVal, ''), 5, 80, array('class' => 'tbox form-control input-block-level e-autoheight e-wysiwyg'));
+	}
+
+
+	function invoice_footer($curVal, $mode)
+	{
+		if (empty($curVal))
+		{
+			$curVal = array(
+				0 => e107::pref('vstore', 'merchant_info'),
+				1 => '<b>Contact</b><br/>Phone: <br/>Email: <br/>Website: ',
+				2 => '<b>Tax information</b><br/>VAT-ID: <br/>Tax code: ',
+				3 => '<b>Bank information</b><br/>Bank: <br/>Owner: <br/>IBAN: <br/>BIC/SWIFT: '
+			);
+		}
+
+		if ($curVal && !is_array($curVal))
+		{
+			$curVal = e107::unserialize($curVal);
+		}
+
+		$frm = e107::getForm();
+
+
+		$text = '
+		<table class="table table-bordered table-striped">
+		<tr>
+			<th>Fieldname</th>
+			<!-- <th>Title</th> -->
+			<th>Text</th>
+		</tr>';
+
+		for($i=0; $i < 4; $i++)
+		{
+			$text .= '
+			<tr>
+				<td>footer' . ($i) . '</td>
+				<td>' . $frm->bbarea('invoice_footer['.$i.']', $curVal[$i],'', '_common', 'small') . '</td>
+			</tr>
+			';
+		}
+
+		$text .= '
+		</table>';
+		return $text;
+	}
+
+	function invoice_next_nr($curVal, $mode)
+	{
+		$next = vstore::getNextInvoiceNr();
+		if ($curVal < $next)
+		{
+			$curVal = $next;
+		}
+
+		return e107::getForm()->number('invoice_next_nr', $curVal);
+
+	}
+
+}		
+
+?>

--- a/inc/admin_config_orders.php
+++ b/inc/admin_config_orders.php
@@ -29,9 +29,10 @@ class vstore_order_ui extends e_admin_ui
 			'order_status'          => array ( 'title' => 'Status', 'type'=>'method', 'data'=>'str', 'inline'=>true, 'filter'=>true, 'batch'=>true,'width'=>'5%'),
 			'order_date'          	=> array ( 'title' => LAN_DATESTAMP, 'type' => 'datestamp', 'data' => 'str',  'readonly'=>true, 'width' => 'auto', 'filter' => true, 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 
+			'order_invoice_nr'     	=> array ( 'title' => 'Invoice Nr', 'type'=>'method', 'data'=>false, 'width'=>'20%'),
 			'order_billing'      	=> array ( 'title' => 'Billing to', 'type'=>'method', 'data'=>false, 'width'=>'20%'),
 			'order_shipping'      	=> array ( 'title' => 'Ship to', 'type'=>'method', 'data'=>false, 'width'=>'20%'),
-			'order_items'     		=> array ( 'title' => "Items", 'type' => 'method', 'data' => false, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'right', 'thclass' => 'right',  ),
+			'order_items'     		=> array ( 'title' => 'Items', 'type' => 'method', 'data' => false, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'right', 'thclass' => 'right',  ),
 			'order_e107_user'     	=> array ( 'title' => LAN_AUTHOR, 'type' => 'method', 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 			'order_pay_gateway'     => array ( 'title' => 'Gateway', 'type' => 'text', 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 			'order_pay_status'      => array ( 'title' => 'Pay Status', 'type' => 'text',  'data' => 'str',  'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
@@ -43,10 +44,11 @@ class vstore_order_ui extends e_admin_ui
 			'order_session'       	=> array ( 'title' => 'Session', 'type' => 'text', 'tab'=>1, 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 			'order_pay_rawdata' 	=> array ( 'title' => 'Rawdata', 'type' => 'method', 'tab'=>1, 'data' => 'str', 'readonly'=>true, 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 			'order_log' 			=> array ( 'title' => 'Log', 'type' => 'method', 'tab'=>2, 'data' => 'json', 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+
 			'options' 				=> array ( 'title' => LAN_OPTIONS, 'type' => null, 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => '1',  ),
 		);
 
-		protected $fieldpref = array('order_id','order_ship_to', 'order_status', 'order_date', 'order_items', 'order_pay_transid','order_pay_amount','order_pay_status');
+		protected $fieldpref = array('order_id','order_ship_to', 'order_status', 'order_invoice_nr', 'order_date', 'order_items', 'order_pay_transid','order_pay_amount','order_pay_status');
 
 
 		// protected $preftabs = array();
@@ -169,7 +171,7 @@ class vstore_order_ui extends e_admin_ui
 				}
 			}
 
-			$new_data['order_log'] = $log; //e107::serialize($log, 'json');
+			$new_data['order_log'] = $log;
 			return $new_data;
 		}
 
@@ -184,8 +186,30 @@ class vstore_order_ui extends e_admin_ui
 					vstore::setCustomerUserclass($old_data['order_e107_user'], json_decode($old_data['order_items'], true));
 				}
 			}
-			// Send our email to customer
+
 			$vs = e107::getSingleton('vstore');
+
+			if (isset($_POST['force_new_invoice']) && intval($_POST['force_new_invoice']) == 1 && vstore::validInvoiceOrderState($new_data['order_status']))
+			{
+				// User requests to delete the current invoice pdf and to create a new one.
+				$data = $vs->renderInvoice($new_data['order_id'], true);
+				if ($data)
+				{
+					$vs->invoiceToPdf($data, true);
+				}
+
+				// Check if the pdf was created
+				if (empty($vs->pathToInvoicePdf($new_data['order_invoice_nr'])))
+				{
+					e107::getMessage()->addWarning('Invoice couldn\'t be created!');
+				}
+				else
+				{
+					e107::getMessage()->addSuccess('Invoice successfully created!');
+				}
+			}
+
+			// Send our email to customer
 			$vs->emailCustomerOnStatusChange($new_data['order_id']);
 		}
 
@@ -212,6 +236,47 @@ class vstore_order_ui extends e_admin_ui
 class vstore_order_form_ui extends e_admin_form_ui
 {
 
+	function order_invoice_nr($curVal, $mode)
+	{
+		$status = $this->getController()->getFieldVar('order_status');
+		$exists = false;
+		if (vstore::validInvoiceOrderState($status))
+		{
+			$text = '<a href="' . e107::url('vstore', 'invoice', array('order_invoice_nr' => $curVal)) . '" target="_BLANK">' . vstore::formatInvoiceNr($curVal) . '</a>';
+			$exists = true;
+		}
+		else
+		{
+			$text = vstore::formatInvoiceNr($curVal);
+		}
+
+		switch($mode)
+		{
+			case 'read': // List Page
+				return $text;
+				break;
+
+			case 'write': // Edit Page
+				if ($exists)
+				{
+					return $text . ' &nbsp;&nbsp;&nbsp;&nbsp;' . e107::getForm()->checkbox_label('Check to force the creation of a new invoice pdf during save', 'force_new_invoice', 1);
+				}
+				else
+				{
+					return $text;
+				}
+				break;
+
+			case 'filter':
+				return null;
+				break;
+
+			case 'batch':
+				return  null;
+				break;
+		}		
+	}
+
 	function order_status($curVal, $mode)
 	{
 
@@ -223,6 +288,13 @@ class vstore_order_form_ui extends e_admin_form_ui
 
 			case 'write': // Edit Page
 				return e107::getForm()->select('order_status', vstore::getStatus(), $curVal);
+				break;
+
+			case 'inline': // Inline Edit Page
+				return array(
+					'inlineType' => 'select',
+					'inlineData' => vstore::getStatus()
+				);
 				break;
 
 			case 'filter':

--- a/inc/admin_config_orders.php
+++ b/inc/admin_config_orders.php
@@ -199,7 +199,7 @@ class vstore_order_ui extends e_admin_ui
 				}
 
 				// Check if the pdf was created
-				if (empty($vs->pathToInvoicePdf($new_data['order_invoice_nr'])))
+				if (empty($vs->pathToInvoicePdf($new_data['order_invoice_nr'], $new_data['order_e107_user'])))
 				{
 					e107::getMessage()->addWarning('Invoice couldn\'t be created!');
 				}

--- a/inc/vstore_pdf.class.php
+++ b/inc/vstore_pdf.class.php
@@ -321,7 +321,8 @@ class vstore_pdf extends TCPDF
 		$this->SetFont('helvetica', '', 8);
 		// Page number
         $this->writeHTML($this->footer_text, true, false, false, false, 'L');
-        $this->Cell(0, 5, PDF_LAN_19 . ' ' . $this->getAliasNumPage() . '/' . $this->getAliasNbPages(), 0, 1, 'C');
+        $this->Cell(0, 5, PDF_LAN_19 . ' ' . $this->getAliasNumPage() . '/' . $this->getAliasNbPages(), 0, 0, 'C');
+        $this->Cell(0, 5, 'Document created: ' . e107::getDateConvert()->convert_date(time(), 'short'), 0, 1, 'R');
 	}
 
     /**

--- a/inc/vstore_pdf.class.php
+++ b/inc/vstore_pdf.class.php
@@ -1,0 +1,369 @@
+<?php
+/*
+ * e107 website system
+ *
+ * Copyright (C) 2008-2013 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ *
+ * Plugin - PDF generator
+ *
+ * $URL$
+ * $Id$
+ */
+
+
+/**
+ *	e107 pdf generation plugin
+ *
+ *	@package	e107_plugins
+ *	@subpackage	pdf
+ *	@version 	$Id$;
+ */
+
+if (!defined('e107_INIT')) { exit; }
+
+ob_start(); // DO NOT REMOVE, USED TO PREVENT TCPDF SENTE HEADERS ERROR!!!!!!!
+/*
+TODO:
+1. Look at using disc cache
+2. More detailed check on image paths
+*/
+
+// Debug option - adds entries to rolling log (only works in 0.8)
+//define ('PDF_DEBUG', TRUE);
+define ('PDF_DEBUG', FALSE);
+
+define('K_PATH_MAIN', e_PLUGIN.'pdf/');
+define('K_PATH_URL', SITEURL);			// Used with forms (TODO: check validity)
+define('K_CELL_HEIGHT_RATIO', 1.25);
+
+// Following may be used (among others)
+//define ('K_PATH_FONTS', K_PATH_MAIN.'fonts/');
+define ('K_PATH_CACHE', e_CACHE_CONTENT);
+define ('K_PATH_URL_CACHE', K_PATH_URL.e_CACHE_CONTENT);
+define ('K_PATH_IMAGES', K_PATH_MAIN.'images/');
+define ('K_BLANK_IMAGE', K_PATH_IMAGES.'_blank.png');
+
+/*
+The full tcpdf distribution includes a utility to generate new fonts, as well as lots of other fonts.
+It can be downloaded from: http://sourceforge.net/projects/tcpdf/
+*/
+
+
+require_once(e_PLUGIN.'pdf/tcpdf.php');		//require the ufpdf class
+include_lan(e_PLUGIN.'pdf/languages/'.e_LANGUAGE.'_admin_pdf.php');
+
+
+/**
+ * Vstore PDF class
+ */
+class vstore_pdf extends TCPDF
+{
+
+    protected $pdfPref = array();			// Prefs - loaded before creating a pdf
+    private $footer_text = '';
+
+    /**
+     *	Constructor
+     * @param string $orientation page orientation. Possible values are (case insensitive):<ul><li>P or Portrait (default)</li><li>L or Landscape</li></ul>
+     * @param string $unit User measure unit. Possible values are:<ul><li>pt: point</li><li>mm: millimeter (default)</li><li>cm: centimeter</li><li>in: inch</li></ul><br />A point equals 1/72 of inch, that is to say about 0.35 mm (an inch being 2.54 cm). This is a very common unit in typography; font sizes are expressed in that unit.
+     * @param mixed $format The format used for pages. It can be either one of the following values (case insensitive) or a custom format in the form of a two-element array containing the width and the height (expressed in the unit given by unit).<ul><li>4A0</li><li>2A0</li><li>A0</li><li>A1</li><li>A2</li><li>A3</li><li>A4 (default)</li><li>A5</li><li>A6</li><li>A7</li><li>A8</li><li>A9</li><li>A10</li><li>B0</li><li>B1</li><li>B2</li><li>B3</li><li>B4</li><li>B5</li><li>B6</li><li>B7</li><li>B8</li><li>B9</li><li>B10</li><li>C0</li><li>C1</li><li>C2</li><li>C3</li><li>C4</li><li>C5</li><li>C6</li><li>C7</li><li>C8</li><li>C9</li><li>C10</li><li>RA0</li><li>RA1</li><li>RA2</li><li>RA3</li><li>RA4</li><li>SRA0</li><li>SRA1</li><li>SRA2</li><li>SRA3</li><li>SRA4</li><li>LETTER</li><li>LEGAL</li><li>EXECUTIVE</li><li>FOLIO</li></ul>
+     * @param boolean $unicode TRUE means that the input text is unicode (default = true)
+     * @param boolean $diskcache if TRUE reduce the RAM memory usage by caching temporary data on filesystem (slower).
+     * @param String $encoding charset encoding; default is UTF-8
+     */
+    public function __construct($orientation = 'P', $unit = 'mm', $format = 'A4', $unicode = true, $encoding = 'UTF-8', $diskcache = false)
+    {
+        // $this->getPDFPrefs();
+        $this->pdfPref = $this->getDefaultPDFPrefs();
+
+       //Call parent constructor
+        parent::__construct($orientation, $unit, $format, $unicode, $encoding, $diskcache);
+       //Initialization
+        $this->setCellHeightRatio(1.25);			// Should already be the default
+    }
+
+    function __set($name, $value)
+    {
+        if (array_key_exists($name, $this->pdfPref))
+        {
+            $this->pdfPref[$name] = $value;
+        }
+        return $this;
+    }
+
+    function __get($name)
+    {
+        if (array_key_exists($name, $this->pdfPref))
+        {
+            return $this->pdfPref[$name];
+        }
+        return null;
+    }
+
+
+
+   //default preferences if none present
+    function getDefaultPDFPrefs()
+    {
+        $pdfpref['pdf_path'] = '';
+        $pdfpref['pdf_output'] = 'I';
+        $pdfpref['pdf_margin_left'] = '25';
+        $pdfpref['pdf_margin_right'] = '15';
+        $pdfpref['pdf_margin_top'] = '15';
+        $pdfpref['pdf_font_family'] = 'helvetica';
+        $pdfpref['pdf_font_size'] = '8';
+        $pdfpref['pdf_font_size_sitename'] = '14';
+        $pdfpref['pdf_font_size_page_url'] = '8';
+        $pdfpref['pdf_font_size_page_number'] = '8';
+        $pdfpref['pdf_show_logo'] = true;
+        $pdfpref['pdf_show_sitename'] = true;
+        $pdfpref['pdf_show_page_url'] = false;
+        $pdfpref['pdf_show_page_number'] = false;
+        $pdfpref['pdf_error_reporting'] = false;
+        return $pdfpref;
+    }
+
+
+//     /**
+//      *	Set up the e107 PDF prefs - if can't be loaded from the DB, force some sensible defaults
+//      */
+//    //get preferences from db
+//     function getPDFPrefs()
+//     {
+//         $this->pdfPref = e107::pref('pdf');         // retrieve pref array.
+//         if (count($this->pdfPref) == 0) {
+//             $this->pdfPref = $this->getDefaultPDFPrefs();
+//         }
+
+//         return $this->pdfPref;
+//     }
+
+
+    /**
+     *	Convert e107-encoded text to body text
+     *	@param string $text
+     *	@return string with various entities replaced with their equivalent characters
+     */
+    function toPDF($text)
+    {
+        $search = array('&#39;', '&#039;', '&#036;', '&quot;');
+        $replace = array("'", "'", '$', '"');
+        $text = str_replace($search, $replace, $text);
+        return $text;
+    }
+
+
+
+    /**
+     *	Convert e107-encoded text to title text
+     *	@param string $text
+     *	@return string with various characters replaced with '-'		TODO: Why?
+     */
+    function toPDFTitle($text)
+    {
+        $search = array(":", "*", "?", '"', '<', '>', '|');
+        $replace = array('-', '-', '-', '-', '-', '-', '-');
+        $text = str_replace($search, $replace, $text);
+        return $text;
+    }
+
+
+
+    /**
+     *	The makePDF function does all the real parsing and composing
+     *	@param array $text needs to be an array containing the following:
+     *	            $text = array($text, $creator, $author, $title, $subject, $keywords, $url[, $orientation]);
+     *	@return - none (the PDF file is output, all being well)
+     */
+    function makePDF($text, $footer='', $creator='', $author='', $title='', $subject='', $keywords='', $url='', $logo='')
+    {
+        $tp = e107::getParser();
+
+        $this->footer_text = $footer;
+
+        if (!empty($logo))
+        {
+            define('PDFLOGO', $logo);					//define logo to add in header
+        }
+
+       //parse the data
+        $title = $this->toPDF($title);				//replace some in the title
+        $title = $this->toPDFTitle($title);			//replace some in the title
+        foreach ($text as $k => $v) {
+            $text[$k] = $tp->toHTML($v, true, 'BODY');
+        }
+
+
+       //set some variables
+        $this->SetMargins($this->pdfPref['pdf_margin_left'], $this->pdfPref['pdf_margin_top'], $this->pdfPref['pdf_margin_right']);
+
+        $this->SetAutoPageBreak(true, 25);			// Force new page break at 25mm from bottom
+        $this->SetPrintHeader(true);
+        $this->SetCellPadding(0);
+
+        $tagvs = array('p' => array(0 => array('h' => 0, 'n' => 0), 1 => array('h' => 0, 'n' => 0)));
+        $this->setHtmlVSpace($tagvs);
+        $this->setCellHeightRatio(1.25);
+        $this->setImageScale(0.47);
+
+
+       //start creating the pdf and adding the data
+        $this->DefOrientation = 'L'; 	        // Page orientation - P=portrait, L=landscape
+
+        $this->getAliasNbPages();				//calculate current page + number of pages
+        $this->AddPage();						//start page
+
+        $this->SetFont($this->pdfPref['pdf_font_family'], '', $this->pdfPref['pdf_font_size']);				//set font
+        $this->SetHeaderFont(array($this->pdfPref['pdf_font_family'], '', $this->pdfPref['pdf_font_size']));
+        $this->SetFooterFont(array($this->pdfPref['pdf_font_family'], '', $this->pdfPref['pdf_font_size']));
+
+
+        $this->WriteHTML($text, true);			//write text		TODO: possibly other parameters
+        $this->SetCreator($creator);			//name of creator
+        $this->SetAuthor($author);				//name of author
+        $this->SetTitle($title);				//title
+        $this->SetSubject($subject);			//subject
+        $this->SetKeywords($keywords);			//space/comma separated
+
+        $file = e107::getForm()->name2id($title) . '.pdf';  //name of the file
+
+        if (!empty($this->pdfPref['pdf_path']))
+        {
+            $file = $this->pdfPref['pdf_path'] . $file;
+        }
+
+        $this->Output($file, $this->pdfPref['pdf_output']);	//Save PDF to file (D = output to download window)
+        return;
+    }
+
+
+
+    /**
+     *	Add e107-specific header to each page.
+     *	Uses various prefs set in the admin page.
+     *	Overrides the tcpdf default header function
+     */
+    function Header()
+    {
+        $pageWidth = $this->getPageWidth();		// Will be 210 for A4 portrait
+        $ormargins = $this->getOriginalMargins();
+        $headerfont = $this->getHeaderFont();
+        $headerdata = $this->getHeaderData();
+
+        $topMargin = $this->pdfPref['pdf_margin_top'];
+        if ($this->pdfPref['pdf_show_logo']) {
+            $this->SetFont($this->pdfPref['pdf_font_family'], '', $this->pdfPref['pdf_font_size']);
+            // $this->Image(PDFLOGO, $this->GetX(), $topMargin);
+            $this->Image(PDFLOGO, $pageWidth-$this->rMargin-35, $topMargin, 35, 35, '', '', '', true, 300, '', false, false, 0, true, false, false);
+            $imgx = $this->getImageRBX();
+            $imgy = $this->getImageRBY();			// Coordinates of bottom right of logo
+
+            $a = $this->GetStringWidth(SITENAME);
+            // $b = $this->GetStringWidth(PDFPAGEURL);
+            $b = $this->GetStringWidth(SITETAG);
+            $c = max($a, $b) + $this->rMargin;
+            if (($imgx + $c) > $pageWidth)			// See if room for other text to right of logo
+            {	// No room - move to underneath
+                $this->SetX($this->lMargin);
+                $this->SetY($imgy + 2);
+            } else {
+                $m = 0;
+                if ($this->pdfPref['pdf_show_sitename']) {
+                    $m = 5;
+                }
+                $this->SetX($imgx);						// May not be needed
+                $newY = max($topMargin, $imgy - $m);
+                $this->SetY($newY);						//Room to right of logo - calculate space to line up bottom of text with bottom of logo
+            }
+        } else {
+            $this->SetY($topMargin);
+        }
+        $this->SetY($topMargin);
+       
+       // Now print text - 'cursor' positioned in correct start position
+        $cellwidth = $pageWidth - $this->GetX() - $this->rMargin;
+        $align = 'L';
+
+        if ($this->pdfPref['pdf_show_sitename']) {
+            $this->SetY($topMargin + 2);
+            $this->SetFont($this->pdfPref['pdf_font_family'], 'B', $this->pdfPref['pdf_font_size_sitename']);
+            $this->Cell($cellwidth, 5, SITENAME, 0, 1, $align);
+            $this->SetFont($this->pdfPref['pdf_font_family'], 'I', ($this->pdfPref['pdf_font_size_page_url']));
+            $this->Cell($cellwidth, 5, SITETAG, 0, 1, $align);
+        }
+
+        if ($this->pdfPref['pdf_show_page_number']) {
+            $this->SetFont($this->pdfPref['pdf_font_family'], '', $this->pdfPref['pdf_font_size_page_number']);
+            $this->Cell($cellwidth, 5, PDF_LAN_19 . ' ' . $this->getAliasNumPage() . '/' . $this->getAliasNbPages(), 0, 1, $align);
+        }
+
+        $this->SetFont($this->pdfPref['pdf_font_family'], '', $this->pdfPref['pdf_font_size']);
+
+       // Following cloned from tcpdf header function
+        $this->SetY((2.835 / $this->getScaleFactor()) + max($imgy, $this->GetY()));		// 2.835 is number of pixels per mm
+        if ($this->getRTL()) {
+            $this->SetX($ormargins['right']);
+        } else {
+            $this->SetX($ormargins['left']);
+        }
+        $this->Cell(0, 0, '', 'T', 0, 'C');			// This puts a line between header and text
+
+        $this->SetTopMargin($this->GetY() + 2);		// FIXME: Bodge to force main body text to start below header
+    }
+
+    // Page footer
+	public function Footer() {
+		// Position at 15 mm from bottom
+		$this->SetY(-35);
+		// Set font
+		$this->SetFont('helvetica', '', 8);
+		// Page number
+        $this->writeHTML($this->footer_text, true, false, false, false, 'L');
+        $this->Cell(0, 5, PDF_LAN_19 . ' ' . $this->getAliasNumPage() . '/' . $this->getAliasNbPages(), 0, 1, 'C');
+	}
+
+    /**
+     *	Override standard function to use our own font directory
+     */
+    protected function _getfontpath()
+    {
+       //return str_replace(e_HTTP, e_ROOT, e_PLUGIN_ABS.'pdf/fonts/');
+        return e_PLUGIN . 'pdf/fonts/';
+    }
+
+
+
+    /**
+     *	Called by tcpdf when it encounters a file reference - e.g. source file name in 'img' tag - so we can tweak the source path
+     *	(tcpdf modified to check for a class extension which adds this method)
+     *	@param string $fileName - name of file as it appears in the 'src' parameter
+     *	@param string $source - name of tag which provoked call (might be useful to affect encoding)
+     *	@return string - file name adjusted to suit tcpdf
+     */
+    function filePathModify($fileName, $source = '')
+    {
+       // This handles the fact that local images use absolute links in web pages
+        if (strpos($fileName, SITEURL) === 0) {
+            $fileName = e_BASE . str_replace(SITEURL, '', $fileName);
+            return $fileName;
+        }
+
+       // Leave off-site links unchanged
+        if (strpos($fileName, 'http://') === 0) return $fileName;
+        if (strpos($fileName, 'https://') === 0) return $fileName;
+        if (strpos($fileName, 'ftp://') === 0) return $fileName;
+       
+       // Assumed to be a 'local' link here
+        if (substr($fileName, 0, 1) == '/') {	// Its an absolute file reference
+            return str_replace(e_HTTP, e_ROOT, $fileName);
+        } else {	// Its a relative link
+            return realpath($fileName);
+        }
+    }
+
+
+}
+
+?>

--- a/invoices/.htaccess
+++ b/invoices/.htaccess
@@ -1,2 +1,0 @@
-Order deny,allow
-Deny from all

--- a/invoices/.htaccess
+++ b/invoices/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all

--- a/templates/vstore_dashboard_template.php
+++ b/templates/vstore_dashboard_template.php
@@ -1,0 +1,97 @@
+<?php
+
+$VSTORE_DASHBOARD_TEMPLATE = array();
+
+
+$VSTORE_DASHBOARD_TEMPLATE['header'] = '
+    <h3>{DASHBOARD: title}</h3>
+
+    {DASHBOARD: nav}
+    <br />
+    <div>
+';
+
+$VSTORE_DASHBOARD_TEMPLATE['footer'] = '
+    </div>
+';
+
+
+/**
+ * Dashboard
+ */
+$VSTORE_DASHBOARD_TEMPLATE['dashboard'] = '
+    <p>From your account dashboard you can view your recent orders, manage your shipping and billing addresses and edit your password and account details.</p>
+';
+
+
+/**
+ * List orders
+ */
+$VSTORE_DASHBOARD_TEMPLATE['order']['list']['header'] = '
+    <table class="table table-bordered table-striped">
+    <thead>
+    <tr>
+        <th>Order info</th>
+        <th>Shipping</th>
+        <th>Items</th>
+        <th>Total</th>
+        <th>Status</th>
+        <th>Actions</th>
+    </tr>
+    </thead>
+    <tbody>
+';
+
+
+$VSTORE_DASHBOARD_TEMPLATE['order']['list']['footer'] = '
+    </tbody>
+    </table>
+';
+
+
+$VSTORE_DASHBOARD_TEMPLATE['order']['list']['item'] = '
+    <tr>
+        <td>
+            Date: {ORDER_DATA: order_date}<br />
+            Order: {ORDER_DATA: order_ref}<br/>
+            Invoice: {ORDER_DATA: order_invoice_nr}
+        </td>
+        <td>{ORDER_DATA: order_shipping_full}</td>
+        <td>{ORDER_DATA: order_items_short}</td>
+        <td>{ORDER_DATA: order_pay_amount}</td>
+        <td>{ORDER_DATA: order_status}</td>
+        <td>{ORDER_ACTIONS}</td>
+    </tr>
+';
+
+
+
+$VSTORE_DASHBOARD_TEMPLATE['order']['detail'] = '
+    <h4>Order details {ORDER_DATA: order_ref}</h4>
+    <div class="clearfix">
+        <div class="col-sm-4">
+            <b>Date</b> {ORDER_DATA: order_date}<br />
+            <b>Order</b> {ORDER_DATA: order_ref}<br/>
+            <b>Invoice</b> {ORDER_DATA: order_invoice_nr}<br/>
+            <b>Payment method</b> {ORDER_DATA: order_gateway}<br/>
+            <b>Payment complete</b> {ORDER_DATA: order_pay_status}<br/>
+        </div>
+
+        <div class="col-sm-4">
+            <b>Shipping address</b> <br />
+            {ORDER_DATA: order_shipping_full}<br/>
+        </div>
+
+        <div class="col-sm-4">
+            <b>Billling address</b> <br />
+            {ORDER_DATA: order_billing_full}<br/>
+        </div>
+    </div>
+
+    <br />
+
+    <div>
+        {ORDER_ITEMS}
+    </div>
+';
+

--- a/templates/vstore_invoice_template.php
+++ b/templates/vstore_invoice_template.php
@@ -10,13 +10,16 @@
 
 	$VSTORE_INVOICE_TEMPLATE = array();
 
-	// Content of the invoice.
+	/** 
+	*  vstore Invoice template for use to be converted to pdf.
 
-
-	// $VSTORE_INVOICE_TEMPLATE['default'] = '
-
-	// {INVOICE_ITEMS}';
-
+	ATTENTION!!!
+	Do mainly use standard html elements as not all html5 tags
+	or css is supported by the pdf plugin (TCPDF)!
+	You need to test ALL changes to the templates 
+	BEFORE using in a production environment!
+	
+	*/
 	$VSTORE_INVOICE_TEMPLATE['default'] = '
 
 <table>

--- a/templates/vstore_invoice_template.php
+++ b/templates/vstore_invoice_template.php
@@ -110,7 +110,8 @@ $VSTORE_INVOICE_TEMPLATE['footer'] = '
 $VSTORE_INVOICE_TEMPLATE['invoice_items']['header'] = '
 <table cellpadding="2" cellspacing="0">
 <tr>
-	<th style="width: 50%;"><b>Description</b></th>
+	<th style="width: 5%;"><b>No.</b></th>
+	<th style="width: 45%;"><b>Product</b></th>
 	<th style="width: 10%;" align="right"><b>Tax</b></th>
 	<th style="width: 15%;" align="right"><b>Unit Price</b></th>
 	<th style="width: 10%;" align="right"><b>Qty</b></th>
@@ -120,6 +121,7 @@ $VSTORE_INVOICE_TEMPLATE['invoice_items']['header'] = '
 
 $VSTORE_INVOICE_TEMPLATE['invoice_items']['row'] = '
 <tr>
+	<td>{CART_DATA: nr}</td>
 	<td>{CART_DATA: name}</td>
 	<td align="right">{CART_DATA: tax}</td>
 	<td align="right">{CART_DATA: price}</td>
@@ -130,10 +132,12 @@ $VSTORE_INVOICE_TEMPLATE['invoice_items']['row'] = '
 $VSTORE_INVOICE_TEMPLATE['invoice_items']['footer'] = '
 <tr>
 	<td></td>
+	<td></td>
 	<td colspan="3"><b>Subtotal</b></td>
 	<td align="right">{CART_DATA: sub_total}</td>
 </tr>
 <tr>
+	<td></td>
 	<td></td>
 	<td colspan="3"><b>Shipping</b></td>
 	<td align="right">{CART_DATA: shipping_total}</td>
@@ -141,6 +145,7 @@ $VSTORE_INVOICE_TEMPLATE['invoice_items']['footer'] = '
 {INVOICE_COUPON}
 {INVOICE_TAX}
 <tr>
+	<td></td>
 	<td></td>
 	<td colspan="3" style="border-top: 1px solid #cccccc"><b>Total</b></td>
 	<td align="right" style="border-top: 1px solid #cccccc"><b>{CART_DATA: grand_total}</b></td>
@@ -151,6 +156,7 @@ $VSTORE_INVOICE_TEMPLATE['invoice_items']['footer'] = '
 $VSTORE_INVOICE_TEMPLATE['invoice_items']['coupon'] = '
 <tr>
 	<td></td>
+	<td></td>
 	<td colspan="3">Coupon: <b>[x]</b></td>
 	<td align="right">[y]</td>
 </tr>
@@ -159,6 +165,7 @@ $VSTORE_INVOICE_TEMPLATE['invoice_items']['coupon'] = '
 
 $VSTORE_INVOICE_TEMPLATE['invoice_items']['tax'] = '
 <tr>
+	<td></td>
 	<td></td>
 	<td colspan="2"><b>Included VAT</b></td>
 	<td align="right">[x]</td>

--- a/templates/vstore_invoice_template.php
+++ b/templates/vstore_invoice_template.php
@@ -1,0 +1,169 @@
+<?php
+	/**
+	 * e107 website system
+	 *
+	 * Copyright (C) 2008-2017 e107 Inc (e107.org)
+	 * Released under the terms and conditions of the
+	 * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+	 *
+	 */
+
+	$VSTORE_INVOICE_TEMPLATE = array();
+
+	// Content of the invoice.
+
+
+	// $VSTORE_INVOICE_TEMPLATE['default'] = '
+
+	// {INVOICE_ITEMS}';
+
+	$VSTORE_INVOICE_TEMPLATE['default'] = '
+
+<table>
+	<thead>
+	<tr>
+		<td style="height:2.5cm" colspan="2">
+			<!-- use the height to adjust the height of the addressfield  -->
+		</td>
+	</tr>
+	<tr>
+		<td width="65%" style="height: 5cm;">
+			<span style="font-size:0.2cm;">{ORDER_MERCHANT_INFO: line}</span><br />
+			<br />
+			{ORDER_DATA: cust_firstname} {ORDER_DATA: cust_lastname}<br />
+			{ORDER_DATA: cust_company}<br />
+			{ORDER_DATA: cust_address}<br />
+			{ORDER_DATA: cust_city} &nbsp;{ORDER_DATA: cust_state} &nbsp;{ORDER_DATA: cust_zip}<br />
+			{ORDER_DATA: cust_country}		
+		</td>
+
+		<td  width="35%">
+			<b>{INVOICE_DATA: info_title}</b><br />
+			Invoice-Nr.: {ORDER_DATA: order_invoice_nr}<br />
+			Order-Nr.: {ORDER_DATA: order_ref}<br />
+			Order date: {ORDER_DATA: order_date}<br />
+			Payment method: {ORDER_DATA: order_gateway}<br />
+			Payment deadline: {INVOICE_DATA: payment_deadline}		
+		</td>
+	</tr>
+
+	<tr>
+		<td colspan="2" style="height: 2.5cm;">
+			<h2>{INVOICE_DATA: title}</h2>
+			<br />
+			{INVOICE_DATA: subject}<br />
+		</td>
+	</tr>
+	</thead>
+
+	<tbody>
+	<tr>
+		<td colspan="2">
+			{INVOICE_ITEMS}
+		</td>
+	</tr>
+
+	<tr>
+		<td colspan="2">
+			{INVOICE_DATA: hint}
+		</td>
+	</tr>
+
+	<tr>
+		<td colspan="2">
+			{INVOICE_DATA: finish_phrase}
+		</td>
+	</tr>
+	</tbody>
+</table>
+
+';
+	
+
+
+$VSTORE_INVOICE_TEMPLATE['footer'] = '
+<table style="height: 3cm">
+<tbody>
+	<tr>
+		<td style="vertical-align:top;font-size:0.25cm;" width="25%">
+			{INVOICE_DATA: footer0}
+		</td>
+		<td style="vertical-align:top;font-size:0.25cm;" width="25%">
+			{INVOICE_DATA: footer1}
+		</td>
+		<td style="vertical-align:top;font-size:0.25cm;" width="25%">
+			{INVOICE_DATA: footer2}
+		</td>
+		<td style="vertical-align:top;font-size:0.25cm;" width="25%">
+			{INVOICE_DATA: footer3}
+		</td>
+	</tr>
+</tbody>
+</table>
+';
+
+/**
+ * Order items list
+ * Used in emails and on order summary and confirmation
+ */		
+
+$VSTORE_INVOICE_TEMPLATE['invoice_items']['header'] = '
+<table cellpadding="2" cellspacing="0">
+<tr>
+	<th style="width: 50%;"><b>Description</b></th>
+	<th style="width: 10%;" align="right"><b>Tax</b></th>
+	<th style="width: 15%;" align="right"><b>Unit Price</b></th>
+	<th style="width: 10%;" align="right"><b>Qty</b></th>
+	<th style="width: 15%;" align="right"><b>Amount</b></th>
+</tr>
+';
+
+$VSTORE_INVOICE_TEMPLATE['invoice_items']['row'] = '
+<tr>
+	<td>{CART_DATA: name}</td>
+	<td align="right">{CART_DATA: tax}</td>
+	<td align="right">{CART_DATA: price}</td>
+	<td align="right">{CART_DATA: quantity}</td>
+	<td align="right">{CART_DATA: item_total}</td>
+</tr>';
+
+$VSTORE_INVOICE_TEMPLATE['invoice_items']['footer'] = '
+<tr>
+	<td></td>
+	<td colspan="3"><b>Subtotal</b></td>
+	<td align="right">{CART_DATA: sub_total}</td>
+</tr>
+<tr>
+	<td></td>
+	<td colspan="3"><b>Shipping</b></td>
+	<td align="right">{CART_DATA: shipping_total}</td>
+</tr>
+{INVOICE_COUPON}
+{INVOICE_TAX}
+<tr>
+	<td></td>
+	<td colspan="3" style="border-top: 1px solid #cccccc"><b>Total</b></td>
+	<td align="right" style="border-top: 1px solid #cccccc"><b>{CART_DATA: grand_total}</b></td>
+</tr>
+</table>
+';
+
+$VSTORE_INVOICE_TEMPLATE['invoice_items']['coupon'] = '
+<tr>
+	<td></td>
+	<td colspan="3">Coupon: <b>[x]</b></td>
+	<td align="right">[y]</td>
+</tr>
+';
+
+
+$VSTORE_INVOICE_TEMPLATE['invoice_items']['tax'] = '
+<tr>
+	<td></td>
+	<td colspan="2"><b>Included VAT</b></td>
+	<td align="right">[x]</td>
+	<td align="right">[y]</td>
+</tr>
+';
+
+?>

--- a/templates/vstore_template.php
+++ b/templates/vstore_template.php
@@ -673,7 +673,7 @@ $VSTORE_TEMPLATE['customer']['guest'] = '
 			</p>
 
 			<div class="form-group">
-				<button name="register" class="btn btn-primary btn-block">Sign up</button>
+				<a class="btn btn-primary btn-block" id="register" href="{SITEURL}signup.php" title="Sign up">Sign up</a>
 			</div>
 		</div>
 
@@ -686,22 +686,25 @@ $VSTORE_TEMPLATE['customer']['guest'] = '
 			</p>
 
 			<div class="form-group">
-				<button name="as_guest" class="btn btn-default btn-block">Order as guest</button>
+				<button name="as_guest" class="btn btn-default btn-block" type="submit" value="guest">Order as guest</button>
 			</div>
 		</div>
 	
 		<div class="col-12 col-xs-12 col-sm-4">
 			<h4>I\'ve got a useraccount</h4>
-
+			
+			<p>Let me login...</p>
+			<form method="post" onsubmit="hashLoginPassword(this);return true" accept-charset="UTF-8">
 			<div class="form-group">
-				<input type="text" name="username" id="username" class="form-control input-sm" placeholder="Username or email address">
+				<input type="text" name="username" id="username" class="form-control input-sm tbox login user" placeholder="Username or email address" value="" maxlength="100">
 			</div>
 			<div class="form-group">
-				<input type="password" name="password" id="password" class="form-control input-sm" placeholder="Password">
+				<input type="password" name="userpass" id="userpass" class="form-control input-sm tbox login pass" placeholder="Password" size="15" value="" maxlength="30">
 			</div>
 			<div class="form-group">
-				<button name="login" class="btn btn-default btn-block">Login</button>
+				<button name="userlogin" class="btn btn-default btn-block" type="submit">Login</button>
 			</div>
+			</form>
 		</div>
 
 	</div>

--- a/templates/vstore_template.php
+++ b/templates/vstore_template.php
@@ -664,16 +664,46 @@ $VSTORE_TEMPLATE['customer']['additional']['item'] = '
 
 $VSTORE_TEMPLATE['customer']['guest'] = '
 	<div class="row">
-		<div class="col-12 col-xs-12 col-sm-6">
+		<div class="col-12 col-xs-12 col-sm-4">
+			<h4>I\'m a new customer</h4>
+
+			<p>By signing up on our site, you are able to order quicker, 
+			know always the state of your orders and have always an 
+			up-to-date overview about your orders.
+			</p>
+
+			<div class="form-group">
+				<button name="register" class="btn btn-primary btn-block">Sign up</button>
+			</div>
+		</div>
+
+		<div class="col-12 col-xs-12 col-sm-4">
+			<h4>Order as guest</h4>
+
+			<p>When ordering as guest, no user account will be created.<br/>
+			That means, in case of another order, you will have to enter
+			all information once again.
+			</p>
+
+			<div class="form-group">
+				<button name="as_guest" class="btn btn-default btn-block">Order as guest</button>
+			</div>
+		</div>
+	
+		<div class="col-12 col-xs-12 col-sm-4">
+			<h4>I\'ve got a useraccount</h4>
+
+			<div class="form-group">
+				<input type="text" name="username" id="username" class="form-control input-sm" placeholder="Username or email address">
+			</div>
 			<div class="form-group">
 				<input type="password" name="password" id="password" class="form-control input-sm" placeholder="Password">
 			</div>
-		</div>
-		<div class="col-12 col-xs-12 col-sm-6">
 			<div class="form-group">
-				<input type="password" name="password_confirmation" id="password_confirmation" class="form-control input-sm" placeholder="Confirm Password">
+				<button name="login" class="btn btn-default btn-block">Login</button>
 			</div>
 		</div>
+
 	</div>
 ';
 

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -2103,12 +2103,12 @@ class vstore
 		 * End
 		 */
 
-		if(!USER)
-		{
+		// if(!USER)
+		// {
 
-			$text .= e107::getParser()->parseTemplate($template['guest'], true, $this->sc);
+		// 	$text .= e107::getParser()->parseTemplate($template['guest'], true, $this->sc);
 
-		}
+		// }
 
 		return $text;
 
@@ -2563,7 +2563,7 @@ class vstore
 		$active = $this->getActiveGateways();
 		$curGateway = $this->getGatewayType();
 
-		if(!USER)
+		if(!USER && !isset($_POST['as_guest']))
 		{
 			// TODO: Fill with life ...
 			$text = e107::getForm()->open('gateway-select','post', e107::url('vstore', 'checkout', 'sef'), array('class'=>'form'));
@@ -2572,7 +2572,6 @@ class vstore
 
 
 			return $text;
-
 		}
 
 
@@ -3017,7 +3016,7 @@ class vstore
 		$nid = e107::getDb()->insert('vstore_orders',$insert);
 		if( $nid !== false)
 		{
-			if (!$this->saveCustomer($customerData, $shippingData, $this->getShippingType(), $this->getGatewayType(true)))
+			if (USER && !$this->saveCustomer($customerData, $shippingData, $this->getShippingType(), $this->getGatewayType(true)))
 			{
 				$mes->addError('Unable to save/Update customer data!', 'vstore');
 			}
@@ -4053,7 +4052,7 @@ class vstore
 	 * @param boolean $isCheckoutData true if $data is of type checkout data
 	 * @return array
 	 */
-	public function prepareCheckoutData($data, $isCheckoutData=false)
+	public function prepareCheckoutData($data, $isCheckoutData=false, $fromSitelink=false)
 	{
 		$sql = e107::getDb();
 		$cust = $this->getCustomerData();
@@ -4177,7 +4176,7 @@ class vstore
 		
 		if ($count_active == 0)
 		{
-			return e107::getMessage()->addInfo("Your cart is empty.",'vstore')->render('vstore');
+			return ($fromSitelink ? null : e107::getMessage()->addInfo("Your cart is empty.",'vstore')->render('vstore'));
 		}
 
 

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -5278,7 +5278,13 @@ class vstore
 		if ($saveToDisk)
 		{
 			// Make sure the path is absolute
-			$pdf->pdf_path = str_replace(array("..\\", "../"), '', e_ROOT . e107::getFile()->getUserDir($data['userid'], true));
+			$pdf->pdf_path = realpath(e107::getFile()->getUserDir($data['userid'], true));
+
+			if ($pdf->pdf_path == false || trim($pdf->pdf_path) == '')
+			{
+				e107::getMessage()->addError('Unable to create invoice user folder!', 'vstore');
+				return;
+			}
 			$pdf->pdf_output = 'F';
 		}
 		else
@@ -5312,7 +5318,7 @@ class vstore
 			$e107_user_id = USERID;
 		}
 		$title = varset($this->pref['invoice_title'][e_LANGUAGE], 'Invoice').' '.self::formatInvoiceNr($invoice_nr);
-		$file = e107::getFile()->getUserDir($e107_user_id, true) . e107::getForm()->name2id($title) . '.pdf';
+		$file = e107::getFile()->getUserDir($e107_user_id, false) . e107::getForm()->name2id($title) . '.pdf';
 
 		return (is_readable($file) ? $file : '');
 	}

--- a/vstore_setup.php
+++ b/vstore_setup.php
@@ -132,6 +132,34 @@ class vstore_setup
 				return false;
 			}
 		}
+
+		// Add missing invoice_nr to vstore_orders
+		if($sql->field('vstore_orders','order_invoice_nr'))
+		{
+			$sql = e107::getDb('sql1');
+			$sql2 = e107::getDb('sql2');
+			if ($sql->select('vstore_orders','order_id', 'ISNULL(order_invoice_nr)=true ORDER BY order_id'))
+			{
+				// check pref
+				$pref = e107::pref('vstore', 'invoice_next_nr', 1);
+				if (intval($pref) < 1) $pref = 1;
+				$pref--;
+
+				// get next order_invoice_nr
+				$max = $sql2->retrieve('vstore_orders', 'MAX(order_invoice_nr) AS max');
+				$max = (is_array($max) ? intval($max['max']) : 0);
+				$max = max($pref, $max);
+
+				// Update order_invoice_nr
+				while($row = $sql->fetch())
+				{
+					$id = $row['order_id'];
+					$max++;
+					$sql2->update('vstore_orders', array('data' => array('order_invoice_nr' => $max), 'WHERE' => 'order_id='.$id));
+				}
+				return true;
+			}
+		}
 		return false;
 	}	
 

--- a/vstore_sql.php
+++ b/vstore_sql.php
@@ -44,7 +44,8 @@ CREATE TABLE vstore_orders (
   `order_pay_coupon_amount` decimal(10,2) NOT NULL DEFAULT '0.00',
   `order_pay_rawdata` text,
   `order_log` text,
-  PRIMARY KEY (`order_id`)
+  PRIMARY KEY (`order_id`),
+  UNIQUE KEY `order_invoice_nr` (`order_invoice_nr`)
 ) ENGINE=MyISAM;
 
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,5 @@
+Welcome to the vstore wiki!
+
+
+ 
+[Invoices](invoices.md)

--- a/wiki/invoice.md
+++ b/wiki/invoice.md
@@ -1,0 +1,67 @@
+# Invoices
+
+**In order to make the invoices work, you MUST install the PDF plugin!**
+
+You can find the latest version here: https://github.com/e107inc/pdf
+
+
+## Contents
+
+1. Required settings
+2. Other settings
+3. Templates
+4. Various
+
+
+## Required settings
+
+A few settings have to be done by the shop admin after installation to make sure the invoices are correctly created.
+
+1. Make sure you have a merchant address entered (Preferences -> Emails -> Merchant Name/Address). This is used on the invoice at various places.
+
+2. Check/Update the content of the footer (Invoice settings -> Footer content -> footer0, footer1, footer2, footer3).  This elements (footer0 to footer3) will be rendered at the footer of your invoice in 4 boxes.  
+footer0 contains usually the merchant information. You may have to format it to your liking. Be aware that the space is limited to 5 rows.  
+footer1 may contain direct contact information like phone number, email adress or website.  
+footer2 can be used to tax information like your VAT-ID (if you're from the EU or your tax code).  
+footer 3 can be used to display bank information (e.g. Bank name, Account owner, IBAN, BIC/SWIFT codes).  
+Of course, it is up to you (and your local regulations), which information you enter and into which footer box.
+
+
+## Other settings
+
+This is a brief descriptions of the settings for invoices:
+
+- Title: Is the title used on the invoice. By default it is `INVOICE`.
+- Information section caption: This is the caption of the block on the top right, which contains information like Invoice nr., Order-Nr. and so on.
+- Subject: This sentence is rendered right below the "Title" and above the list of purchased items. Usually it's something like "This is the invoice vor order #HGJ0981 from 2015-05-15 : 16:20"  
+You can use shortcodes like {ORDER_DATA: order_ref} or {ORDER_DATA: order_date} here.
+- Invoice number prefix: All invoice nr will start with this prefix. e.g. IN will render as "IN0123456".
+- Next invoice number: This shows you the next invoice number that the system will use. But in case you come from a different shop system and do not want to start your invoice nr at 1 you can overwrite it with your desired number.  
+**If you enter a number, smaller than current last used invoice number, it will be ignored! And the next invoice nr generated will be in sequence to the last used number!**
+- Invoice date format: As you usually do not need the time in your invoice date, you should specify your date format here. Default is `%m/%d/%Y`
+- Default payment deadline (days): Defines a number of dates, till when the invoice should be payed. Default is `7`, but you can change it to your liking.  
+It is rendered in the "Information section".
+- Hint: Here you can enter and format some text that you want to render right below the items list. maybe something like `Please checkout also our other products.` or something like that.
+- Finishing phrase: This will be rendered right below the "Hint" and is by default something like  
+`Thanks for your business!  
+Yours faithfully
+<your name>
+_____________________________________________`
+- Footer content: This define 4 boxes, which will be rendered on the bottom of the page (on every page!).
+
+
+## Templates
+
+The invoice is based on a template `template_invoice.php` that can be found in the `templates` folder. you can change the template to your liking, but make sure to test the resulting invoice pdf extensingly as the html to pdf converter doesn't support all html5 tags or css rules!
+
+
+## Various
+
+- Invoices will be created when the order is saved to the database.
+- Invoices will be saved to the e107 Media datastore
+- Invoices will be attached to emails that are send and are in one of the following states: **N**ew, **C**omplete, **P**rocessing
+- Invoices are online accessible via the following scheme: http://example.com/vstore/invoice/<invoice_nr>  
+**Only admins and the customer can access the invoice via that link.**
+- In case, an invoice must be recreated, you can do this via the admin area:  
+Open the order in edit mode, mark the checkbox near to the invoice nr. and click update.  
+This will delete the current invoice from the media datastore and create a new one. **It will NOT be automatically send anywhere!**


### PR DESCRIPTION
## Invoices (PDF & Email) #61 

- Invoices will be generated on order save (saveTransaction)
- Generated invoices will be saved as pdf in sub-folder invoices
- Invoices will be attached to emails when order in status *N*ew, *C*omplete, *P*rocessing
- In case there is the need to "update" a invoice, it can be done via admin. Edit order, mark the checkbox near the invoice nr and lick update. The invoice will be recreated based on the current order data.
- Included creation date time in invoice footer

## Guest purchases #75
- Implemented a solution to allow guest purchases (Guest will be able to choose if he want's to create a user account, login to an existing account or continue as a guest)

## Customer dashboard #77 
Added a first version of the dashboard.
![grafik](https://user-images.githubusercontent.com/7572616/39311914-796e6516-496e-11e8-8466-48baa964ac89.png)
- Dashboard menu with the various areas (still incomplete)
- List orders of the customer.
- Show order details.
- Enable the user to cancel an order (when in state "New", "Processing", "On Hold").
- An email will be send to the customer after cancellation, informing about this change.

## Various changes / fixes
- Fixed issue, where the order status could not be inline edited in admin
- Fixed an issue, where the "Order complete" message wasn't displayed at all

## Documentation
As i don't have push access to the original vstore wiki and i have no clue if it would work (with PR) if i create a wiki on my fork, i decided to create a subfolder (wiki) and to start documenting (*.md files) here ...
Maybe there is an easier ways of doing it. In that case, I'll change it.