### PR TITLE
Customer dashboard #77

### DIFF
--- a/e_url.php
+++ b/e_url.php
@@ -21,16 +21,16 @@ class vstore_url // plugin-folder + '_url'
 	{
 		$config = array();
 
-		$config['dashboard_do'] = array(
+		$config['dashboard_action'] = array(
 			'regex'			=> '^{alias}\/my\/?([a-zA-Z]*)\/?([a-zA-Z]*)\/?([\d]*)\/?$',
-			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=dashboard&area=$1&do=$2&id=$3',
-			'sef'			=> '{alias}/my/{dashboard}/{action}/{id}'
+			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=dashboard&area=$1&action=$2&id=$3',
+			'sef'			=> '{alias}/my/{dash}/{action}/{id}'
 		);
 
 		$config['dashboard'] = array(
 			'regex'			=> '^{alias}\/my\/?([a-zA-Z]*)\/?\??',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=dashboard&area=$1&',
-			'sef'			=> '{alias}/my/{dashboard}'
+			'sef'			=> '{alias}/my/{dash}'
 		);
 
 		$config['invoice'] = array(

--- a/e_url.php
+++ b/e_url.php
@@ -21,16 +21,16 @@ class vstore_url // plugin-folder + '_url'
 	{
 		$config = array();
 
-		$config['dashboard'] = array(
-			'regex'			=> '^{alias}\/my\/?([a-zA-Z]*)\/?\??',
-			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=dashboard&area=$1&',
-			'sef'			=> '{alias}/my/{dashboard}'
-		);
-
 		$config['dashboard_do'] = array(
 			'regex'			=> '^{alias}\/my\/?([a-zA-Z]*)\/?([a-zA-Z]*)\/?([\d]*)\/?$',
 			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=dashboard&area=$1&do=$2&id=$3',
 			'sef'			=> '{alias}/my/{dashboard}/{action}/{id}'
+		);
+
+		$config['dashboard'] = array(
+			'regex'			=> '^{alias}\/my\/?([a-zA-Z]*)\/?\??',
+			'redirect'		=> '{e_PLUGIN}vstore/vstore.php?mode=dashboard&area=$1&',
+			'sef'			=> '{alias}/my/{dashboard}'
 		);
 
 		$config['invoice'] = array(

--- a/inc/vstore_dashboard.class.php
+++ b/inc/vstore_dashboard.class.php
@@ -1,0 +1,405 @@
+<?php
+if (!defined('e107_INIT')) { exit; }
+
+
+class vstore_dashboard extends vstore
+{
+
+    protected $dashboards;
+
+    protected $area;
+    protected $action;
+    protected $id;
+    protected $limit_from;
+    protected $tp;
+    protected $sql;
+    protected $template;
+
+
+    public function __construct()
+    {
+		Parent::__construct();
+
+		$this->dashboards = array(
+			'dashboard' => 'Dashboard', 
+			'orders' => 'My orders', 
+			'downloads' => 'My downloads', 
+			'addresses' => 'My adresses', 
+			'account' => 'My account'
+		);
+
+        $this->area = strtolower(trim(varsettrue($this->get['area'], 'dashboard')));
+        $this->action = strtolower(trim(varsettrue($this->get['action'], '')));
+        $this->id = intval(varsettrue($this->get['id'], 0));
+
+		$this->tp = e107::getParser();
+		$this->sql = e107::getDb();
+
+        $this->template = e107::getTemplate('vstore', 'vstore_dashboard');
+		$this->from = vartrue($this->get['page'],1);
+
+		$this->from = vartrue($this->get['page'],1);
+		$this->limit_from = ($this->from - 1) * $this->perPage;        
+    }
+
+
+	/**
+	 * Render the customers shop dashboard
+	 *
+	 * @return string
+	 */
+	public function render()
+	{
+		// Access only for logged in users
+		if (!USER) {
+			e107::getMessage()->addError('You need to <a href="'.SITEURL.'login.php">login</a> to access this page!', 'vstore');
+			return '';
+		}
+
+		$this->sc->setVars(array('nav' => $this->dashboards, 'area' => $this->area));
+
+		$text = $this->tp->parseTemplate($this->template['header'], true, $this->sc);
+
+        $method = $this->area . '_' . $this->action;
+
+        if (method_exists($this, $method) && $this->id)
+        {
+            $text .= $this->$method();
+        }
+        elseif (method_exists($this, $this->area))
+        {
+            $method = $this->area;
+            $text .= $this->$method();
+        }
+        else
+        {
+            e107::getMessage()->addError('Dashboard area "'.$this->dashboards[$this->area].'" not implemented yet!', 'vstore');
+        }
+
+		$text .= $this->tp->parseTemplate($this->template['footer'], true, $this->sc);
+		return $text;
+
+	}
+
+
+	/**
+	 * Dashboard landing page
+	 *
+	 * @return string
+	 */
+    private function dashboard()
+    {
+        return $this->tp->parseTemplate($this->template['dashboard'], true, $this->sc);
+    }
+
+
+	/**
+	 * Render list of orders
+	 *
+	 * @return string
+	 */
+    private function orders()
+    {
+        $text = '';
+        // List the orders
+        if ($this->sql->gen('SELECT SQL_CALC_FOUND_ROWS *, o.* FROM `#vstore_orders` o WHERE order_e107_user = '.USERID.' ORDER BY order_id DESC LIMIT '.$this->limit_from.','.$this->perPage))
+        {
+            $count = e107::getDb()->foundRows();
+
+            $text .= $this->tp->parseTemplate($this->template['order']['list']['header'], true, $this->sc);
+            while($row = $this->sql->fetch())
+            {
+                $this->sc->setVars($row);
+                $text .= $this->tp->parseTemplate($this->template['order']['list']['item'], true, $this->sc);
+            }
+            unset($row);
+
+            $text .= $this->tp->parseTemplate($this->template['order']['list']['footer'], true, $this->sc);
+
+            if ($count > intval($this->perPage))
+            {
+                $nextprev = array(
+                        'tmpl'			=>'bootstrap',
+                        'total'			=> ceil($count / intval($this->perPage)),
+                        'amount'		=> intval($this->perPage),
+                        'current'		=> $this->from,
+                        'type'			=> 'page',
+                        'url'			=> e107::url('vstore','dashboard', array('dash' => 'orders')).'?page=[FROM]'
+                );
+        
+                global $nextprev_parms;
+            
+                $nextprev_parms  = http_build_query($nextprev,false,'&');
+        
+                $text .= $this->tp->parseTemplate("{NEXTPREV: ".$nextprev_parms."}",true);
+            }
+        }
+        else
+        {
+            $text .= '<p>No order has been made yet.</p>';
+        }
+        return $text;
+    }
+
+
+	/**
+	 * Render order details
+	 *
+	 * @return string
+	 */
+    private function orders_view()
+    {
+        $text = '';
+        // Order actions (view, cancel)
+        $data = $this->sql->retrieve('vstore_orders', '*', 'order_invoice_nr='.$this->id.' AND order_e107_user='.USERID);
+        if (!$data)
+        {
+            // Order not found or not assigned to user
+            $text .= '<p>No data found!</p>';
+        }
+        else
+        {
+            // render view order details
+            $this->sc->setVars($data);
+            $text .= $this->tp->parseTemplate($this->template['order']['detail'], true, $this->sc);
+        }
+        return $text;      
+    }
+
+
+	/**
+	 * Render cancel order confirmations
+	 *
+	 * @return string
+	 */
+    private function orders_cancel()
+    {
+        $text = '';
+        // Order actions (view, cancel)
+        $data = $this->sql->retrieve('vstore_orders', '*', 'order_invoice_nr='.$this->id.' AND order_e107_user='.USERID);
+        if (!$data)
+        {
+            // Order not found or not assigned to user
+            $text .= '<p>No data found!</p>';
+        }
+        else
+        {
+            // render cancel order confirmation
+            $text .= e107::getForm()->open('confirm-cancel','post', null, array('class'=>'form'));
+            $text .= '
+                <div class="alert alert-warning" role="alert">Do you really want to cancel your order '.$data['order_refcode'].'?</div>
+                <a href="'.e107::url('vstore', 'dashboard', array('dash' => 'orders')).'" class="btn btn-primary" name="cancel_cancel" id="cancel_cancel">No, take me back</a>
+                <button type="submit" class="btn btn-warning" name="cancel_order" id="cancel_order" value="'.$data['order_id'].'">Yes, cancel this order!</button>
+            ';
+            $text .= e107::getForm()->close();
+
+        }
+        return $text;
+    }
+
+
+	/**
+	 * Render paid downloads
+	 *
+	 * @return string
+	 */
+    private function downloads()
+    {
+        $text = '';
+        // List the downloads
+        if ($this->sql->gen('SELECT SQL_CALC_FOUND_ROWS *, o.* FROM `#vstore_orders` o WHERE order_e107_user = '.USERID.' AND order_items REGEXP \'("file": "[a-zA-Z0-9_-]+",)\' AND FIND_IN_SET(order_status, "N,C,P") ORDER BY order_id DESC LIMIT '.$this->limit_from.','.$this->perPage))
+        {
+            $count = e107::getDb()->foundRows();
+
+            $text .= $this->tp->parseTemplate($this->template['download']['list']['header'], true, $this->sc);
+            while($row = $this->sql->fetch())
+            {
+                $this->sc->setVars($row);
+                $text .= $this->tp->parseTemplate($this->template['download']['list']['item'], true, $this->sc);
+            }
+            unset($row);
+
+            $text .= $this->tp->parseTemplate($this->template['download']['list']['footer'], true, $this->sc);
+
+            if ($count > intval($this->perPage))
+            {
+                $nextprev = array(
+                        'tmpl'			=>'bootstrap',
+                        'total'			=> ceil($count / intval($this->perPage)),
+                        'amount'		=> intval($this->perPage),
+                        'current'		=> $this->from,
+                        'type'			=> 'page',
+                        'url'			=> e107::url('vstore','dashboard', array('dash' => 'downloads')).'?page=[FROM]'
+                );
+        
+                global $nextprev_parms;
+            
+                $nextprev_parms  = http_build_query($nextprev,false,'&');
+        
+                $text .= $this->tp->parseTemplate("{NEXTPREV: ".$nextprev_parms."}",true);
+            }
+        }
+        else
+        {
+            $text .= '<p>No downloadable files yet.</p>';
+        }        
+
+        return $text;
+    }
+
+
+	/**
+	 * Render saved addresses
+	 *
+	 * @return string
+	 */
+    private function addresses()
+    {
+        $text = '';
+        // Read data
+        $data = $this->sql->retrieve('vstore_customer', '*', 'cust_e107_user = '.USERID);
+        if ($data)
+        {
+            $this->sc->setVars($data);
+            $text .= $this->tp->parseTemplate($this->template['address']['view'], true, $this->sc);
+        }
+        else
+        {
+            $text .= '<p>No addresses available yet.</p>';
+        }
+        unset($data);        
+        return $text;
+	}
+	
+
+	/**
+	 * Render edit address form
+	 *
+	 * @return string
+	 */
+    private function addresses_edit()
+    {
+        $text = '';
+        // Read data
+        $data = $this->sql->retrieve('vstore_customer', '*', 'cust_e107_user = '.USERID);
+        if ($data)
+        {
+			$frm = e107::getForm();
+
+			$text .= $frm->open('address_edit', 'post');
+
+			if ($this->id === 1) // Billing address
+			{
+
+				foreach ($data as $key => $value) {
+					$key2 = substr($key, 5);
+					$data['cust'][$key2] = $value;
+					unset($data[$key]);
+				}
+				if (!empty($data['cust']['additional_fields']))
+				{
+					$add = e107::unserialize($data['cust']['additional_fields']);
+					foreach ($add as $key => $value) {
+						$data['cust'][$key] = $value;
+					}
+				}
+				//unset($data['cust']['additional_fields']);
+
+
+				/**
+				 * Additional checkout fields
+				 * Start
+				 */
+				$addFieldActive = 0;
+				foreach ($this->pref['additional_fields'] as $k => $v) 
+				{
+					// Check if additional fields are enabled
+					if (vartrue($v['active'], false))
+					{
+						$addFieldActive++;
+					}
+				}
+
+				if ($addFieldActive > 0)
+				{
+					// If any additional fields are enabled
+					// add active fields to form
+					foreach ($this->pref['additional_fields'] as $k => $v) 
+					{
+						if (vartrue($v['active'], false))
+						{
+							$fieldid = 'add_field'.$k;
+							$fieldname = 'cust['.$fieldid.']';
+							if (isset($data['cust'][$fieldid]))
+							{
+								$fieldvalue = $data['cust'][$fieldid]['value'];
+							}
+							else
+							{
+								$fieldvalue = $data['cust']['additional_fields']['value'][$fieldid];
+							}
+							if ($v['type'] == 'text')
+							{
+								// Textboxes
+								$field = $frm->text($fieldname, $fieldvalue, 100, array('placeholder'=>varset($v['placeholder'][e_LANGUAGE], ''), 'required'=>($v['required'] ? 1 : 0)));
+							}
+							elseif ($v['type'] == 'checkbox')
+							{
+								// Checkboxes
+								$field = '<div class="form-control">'.$frm->checkbox($fieldname, 1, 0, array('required'=>($v['required'] ? 1 : 0)));
+								if (vartrue($v['placeholder']))
+								{
+									$field .= ' <label for="'.$frm->name2id($fieldname).'-1" class="text-muted">&nbsp;'.$this->tp->toHTML($v['placeholder'][e_LANGUAGE]).'</label>';
+								}
+								$field .= '</div>';
+							}
+
+							$this->sc->addVars(array(
+								'fieldname' => $fieldname,
+								'fieldcaption' => $this->tp->toHTML(varset($v['caption'][e_LANGUAGE], 'Additional field '.$k)),
+								'field' => $field,
+								'fieldcount' => $addFieldActive,
+								'fieldrequired' => $v['required']
+							));
+
+							$data['cust']['add'][$fieldid] = $this->tp->parseTemplate($this->template['address']['edit']['billing']['additional']['item'], true, $this->sc);
+
+						}
+					}
+
+				}
+
+
+				$this->sc->setVars($data);
+				$text .= $this->tp->parseTemplate($this->template['address']['edit']['billing']['body'], true, $this->sc);
+			}
+			elseif ($this->id === 2) // Shipping address
+			{
+				$data['ship'] = e107::unserialize($data['cust_shipping']);
+				$this->sc->setVars($data);
+				$text .= $this->tp->parseTemplate($this->template['address']['edit']['shipping']['body'], true, $this->sc);
+			}
+			else
+			{
+				e107::getMessage()->addError('Invalid address!', 'vstore');
+			}
+
+			$text .= '
+				<hr/>
+				<div class="text-center">
+				<a href="'.e107::url('vstore', 'dashboard', array('dash' => 'addresses')).'"  class="btn btn-default">Back</a>&nbsp;';
+			$text .= $frm->button('edit_address', $this->id, 'submit', 'Save', array('class' => 'btn btn-primary'));
+			$text .= '</div>';
+
+			$text .= $frm->close();
+        }
+        else
+        {
+            $text .= '<p>No addresses available yet.</p>';
+        }
+        unset($data);        
+        return $text;
+    }	
+}
+
+?>

--- a/inc/vstore_dashboard.class.php
+++ b/inc/vstore_dashboard.class.php
@@ -6,6 +6,7 @@ class vstore_dashboard extends vstore
 {
 
     protected $dashboards;
+    protected $actions;
 
     protected $area;
     protected $action;
@@ -23,10 +24,20 @@ class vstore_dashboard extends vstore
 		$this->dashboards = array(
 			'dashboard' => 'Dashboard', 
 			'orders' => 'My orders', 
-			'downloads' => 'My downloads', 
+			'files' => 'My downloads', 
 			'addresses' => 'My adresses', 
 			'account' => 'My account'
-		);
+        );
+        
+        $this->actions = array(
+            'orders' => array(
+                'view' => 'View details',
+                'cancel' => 'Cancel order'
+            ),
+            'addresses' => array(
+                'edit' => 'Edit address'
+            )
+        );
 
         $this->area = strtolower(trim(varsettrue($this->get['area'], 'dashboard')));
         $this->action = strtolower(trim(varsettrue($this->get['action'], '')));
@@ -42,6 +53,35 @@ class vstore_dashboard extends vstore
 		$this->limit_from = ($this->from - 1) * $this->perPage;        
     }
 
+    /**
+     * Return title for current area
+     *
+     * @return string
+     */
+    public function getArea()
+    {
+        return $this->dashboards[$this->area];
+    }
+
+    /**
+     * Return title for current action
+     *
+     * @return string
+     */
+    public function getAction()
+    {
+        return $this->actions[$this->area][$this->action];
+    }
+
+    /**
+     * return action id
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
 
 	/**
 	 * Render the customers shop dashboard
@@ -203,7 +243,7 @@ class vstore_dashboard extends vstore
 	 *
 	 * @return string
 	 */
-    private function downloads()
+    private function files()
     {
         $text = '';
         // List the downloads
@@ -400,6 +440,18 @@ class vstore_dashboard extends vstore
         unset($data);        
         return $text;
     }	
+
+
+    /**
+     * jump to user profiles
+     *
+     * @return void
+     */
+    private function account()
+    {
+        e107::redirect(SITEURL.'usersettings.php');
+        exit;
+    }
 }
 
 ?>

--- a/templates/vstore_dashboard_template.php
+++ b/templates/vstore_dashboard_template.php
@@ -65,7 +65,9 @@ $VSTORE_DASHBOARD_TEMPLATE['order']['list']['item'] = '
 ';
 
 
-
+/**
+ * Order detail
+ */
 $VSTORE_DASHBOARD_TEMPLATE['order']['detail'] = '
     <h4>Order details {ORDER_DATA: order_ref} <span class="pull-right float-right">{ORDER_DATA: order_status_label}</span></h4>
     <div class="clearfix">
@@ -107,3 +109,64 @@ $VSTORE_DASHBOARD_TEMPLATE['order']['detail'] = '
     </div>
 ';
 
+
+/**
+ * List downloads
+ */
+$VSTORE_DASHBOARD_TEMPLATE['download']['list']['header'] = '
+    <table class="table table-bordered table-striped">
+    <thead>
+    <tr>
+        <th>Order info</th>
+        <th>Items</th>
+        <th>Status</th>
+    </tr>
+    </thead>
+    <tbody>
+';
+
+
+$VSTORE_DASHBOARD_TEMPLATE['download']['list']['footer'] = '
+    </tbody>
+    </table>
+';
+
+
+$VSTORE_DASHBOARD_TEMPLATE['download']['list']['item'] = '
+    <tr>
+        <td>
+            Date: {ORDER_DATA: order_date}<br />
+            Order: {ORDER_DATA: order_ref}<br/>
+            Invoice: {ORDER_DATA: order_invoice_nr}
+        </td>
+        <td>{ORDER_DATA: order_downloads}</td>
+        <td>{ORDER_DATA: order_status_label}</td>
+    </tr>
+';
+
+
+/**
+ * List downloads
+ */
+$VSTORE_DASHBOARD_TEMPLATE['address']['view'] = '
+
+    <div class="col-12 col-xs-12 col-sm-6">
+        <h4>Billing</h4>
+
+        {DASHBOARD: billing_address}
+
+        <br />
+        {DASHBOARD: edit_billing}
+    </div>
+
+    <div class="col-12 col-xs-12 col-sm-6">
+        <h4>Shipping</h4>
+
+        {DASHBOARD: shipping_address}
+
+        <br />
+        {DASHBOARD: edit_shipping}
+    </div>
+    
+
+';

--- a/templates/vstore_dashboard_template.php
+++ b/templates/vstore_dashboard_template.php
@@ -170,3 +170,229 @@ $VSTORE_DASHBOARD_TEMPLATE['address']['view'] = '
     
 
 ';
+
+
+/**
+ * Shipping details form
+ */
+$VSTORE_DASHBOARD_TEMPLATE['address']['edit']['shipping']['body'] = '
+	<h4>Shipping Details</h4>
+
+	<div class="row">
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="ship_firstname" class="required">First Name</label>
+				{SHIPPING_FIELD: ship_firstname}
+			</div>
+		</div>
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="ship_lastname" class="required">Last Name</label>
+				{SHIPPING_FIELD: ship_lastname}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col col-xs-12">
+			<div class="form-group">
+				<label for="ship_company">Company</label>
+				{SHIPPING_FIELD: ship_company}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col col-xs-12">
+			<div class="form-group">
+				<label for="ship_address" class="required">Address</label>
+				{SHIPPING_FIELD: ship_address}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="ship_city" class="required">Town/City</label>
+				{SHIPPING_FIELD: ship_city}
+			</div>
+		</div>
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="ship_state" class="required">State/Region</label>
+				{SHIPPING_FIELD: ship_state}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="ship_zip" class="required">Zip/Postcode</label>
+				{SHIPPING_FIELD: ship_zip}
+			</div>
+		</div>
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="ship_country" class="required">Country</label>
+				{SHIPPING_FIELD: ship_country}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col col-xs-12">
+			<div class="form-group">
+				<label for="ship_phone">Phone number</label>
+				{SHIPPING_FIELD: ship_phone}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-12 col-xs-12">
+			<div class="form-group">
+				<label class="required"></label> Required field
+			</div>
+		</div>
+	</div>
+    ';
+    
+
+/**
+ * Customer details form
+ */
+$VSTORE_DASHBOARD_TEMPLATE['address']['edit']['billing']['body'] = '
+	<h4>Billing address</h4>
+
+	<div class="row">
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="cust_firstname" class="required">First Name</label>
+				{CUSTOMER_FIELD: cust_firstname}
+			</div>
+		</div>
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="cust_lastname" class="required">Last Name</label>
+				{CUSTOMER_FIELD: cust_lastname}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col col-xs-12">
+			<div class="form-group">
+				<label for="cust_company">Company</label>
+				{CUSTOMER_FIELD: cust_company}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="cust_vat_id">VAT ID</label>
+				{CUSTOMER_FIELD: cust_vat_id}
+			</div>
+		</div>
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="cust_taxcode">Tax code</label>
+				{CUSTOMER_FIELD: cust_taxcode}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col col-xs-12">
+			<div class="form-group">
+				<label for="cust_address" class="required">Address</label>
+				{CUSTOMER_FIELD: cust_address}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="cust_city" class="required">Town/City</label>
+				{CUSTOMER_FIELD: cust_city}
+			</div>
+		</div>
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="cust_state">State/Region</label>
+				{CUSTOMER_FIELD: cust_state}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="cust_zip" class="required">Zip/Postcode</label>
+				{CUSTOMER_FIELD: cust_zip}
+			</div>
+		</div>
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="cust_country" class="required">Country</label>
+				{CUSTOMER_FIELD: cust_country}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-12 col-xs-12">
+			<div class="form-group">
+				<label for="cust_email" class="required">Email address</label>
+				{CUSTOMER_FIELD: cust_email}
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="cust_phone">Phone number</label>
+				{CUSTOMER_FIELD: cust_phone}
+			</div>
+		</div>
+		<div class="col-12 col-xs-12 col-sm-6">
+			<div class="form-group">
+				<label for="cust_email">Fax number</label>
+				{CUSTOMER_FIELD: cust_fax}
+			</div>
+		</div>
+	</div>
+
+	{CUSTOMER_FIELD: add_field0}
+
+	{CUSTOMER_FIELD: add_field1}
+	
+	{CUSTOMER_FIELD: add_field2}
+	
+	{CUSTOMER_FIELD: add_field3}
+
+	<div class="row">
+		<div class="col-12 col-xs-12">
+			<div class="form-group">
+				<label class="required"></label> Required field
+			</div>
+		</div>
+	</div>
+';
+
+$VSTORE_DASHBOARD_TEMPLATE['address']['edit']['billing']['additional']['item'] = '
+	<div class="row">
+		<div class="col-12 col-md-12">
+			<div class="form-group">
+				{CUSTOMER_ADD_LABEL}
+				{CUSTOMER_ADD_FIELD}
+			</div>
+		</div>
+	</div>
+';
+    

--- a/templates/vstore_dashboard_template.php
+++ b/templates/vstore_dashboard_template.php
@@ -59,7 +59,7 @@ $VSTORE_DASHBOARD_TEMPLATE['order']['list']['item'] = '
         <td>{ORDER_DATA: order_shipping_full}</td>
         <td>{ORDER_DATA: order_items_short}</td>
         <td>{ORDER_DATA: order_pay_amount}</td>
-        <td>{ORDER_DATA: order_status}</td>
+        <td>{ORDER_DATA: order_status_label}</td>
         <td>{ORDER_ACTIONS}</td>
     </tr>
 ';
@@ -67,7 +67,7 @@ $VSTORE_DASHBOARD_TEMPLATE['order']['list']['item'] = '
 
 
 $VSTORE_DASHBOARD_TEMPLATE['order']['detail'] = '
-    <h4>Order details {ORDER_DATA: order_ref}</h4>
+    <h4>Order details {ORDER_DATA: order_ref} <span class="pull-right float-right">{ORDER_DATA: order_status_label}</span></h4>
     <div class="clearfix">
         <div class="col-sm-4">
             <b>Date</b> {ORDER_DATA: order_date}<br />
@@ -91,7 +91,19 @@ $VSTORE_DASHBOARD_TEMPLATE['order']['detail'] = '
     <br />
 
     <div>
+        <b>Items</b>
         {ORDER_ITEMS}
+    </div>
+
+    <div>
+        <b>Log</b>
+        {ORDER_DATA: order_log}
+    </div>
+
+    <hr />
+
+    <div class="text-center">
+        {ORDER_ACTIONS: cancel}
     </div>
 ';
 

--- a/templates/vstore_template.php
+++ b/templates/vstore_template.php
@@ -721,6 +721,9 @@ $VSTORE_TEMPLATE['navcart']['empty'] = '
 			<br/>
 			<a class="alert-link" href="{CART_DATA: index_url}">Start Shopping</a>
 		</div>
+		<div>
+			<a class="btn btn-block btn-default col-xs-6" href="{CART_DATA: dashboard_url}"><i class="fa fa-tachometer" aria-hidden="true"></i> My Dashboard</a>
+		</div>
 ';
 
 $VSTORE_TEMPLATE['navcart']['header'] = '
@@ -746,6 +749,7 @@ $VSTORE_TEMPLATE['navcart']['footer'] = '
 		<div>
 			<a class="btn btn-block btn-danger" href="#" onclick="vstoreCartReset()"><i class="fa fa-trash-o" aria-hidden="true"></i> Clear cart</a>
 			<a class="btn btn-block btn-primary col-xs-6" href="{CART_DATA: cart_url}"><i class="fa fa-shopping-cart" aria-hidden="true"></i> Checkout</a>
+			<a class="btn btn-block btn-default col-xs-6" href="{CART_DATA: dashboard_url}"><i class="fa fa-tachometer" aria-hidden="true"></i> My Dashboard</a>
 		</div>
 ';
 

--- a/vstore.class.php
+++ b/vstore.class.php
@@ -1333,6 +1333,9 @@ class vstore_plugin_shortcodes extends e_shortcode
 			case 'cart_url': 
 				$text = e107::url('vstore','cart');
 				break;
+			case 'dashboard_url': 
+				$text = e107::url('vstore','dashboard', array('dash' => 'dashboard'));
+				break;
 			case 'coupon':
 				$text = $this->var['cart_coupon']['code'];
 				break;
@@ -2838,6 +2841,24 @@ class vstore
 			$array[] = array('url'=> e107::url('vstore','cart'), 'text'=> "Shopping Cart");
 			$array[] = array('url'=> null, 'text'=> "Checkout");
 
+		}
+
+		if($this->get['mode'] == 'dashboard')
+		{
+			if (!empty(trim($this->get['area'])))
+			{
+				include_once 'inc/vstore_dashboard.class.php';
+				$dashboard = new vstore_dashboard();
+				$array[] = array('url'=> e107::url('vstore','dashboard', array('dash' => $this->get['area'])), 'text'=> $dashboard->getArea());
+				if (!empty(trim($this->get['action'])))
+				{
+					$array[] = array('url'=> e107::url('vstore','dashboard_action', array('dash' => $this->get['area'], 'action' => $this->get['action'], 'id' => $dashboard->getId())), 'text'=> $dashboard->getAction());
+				}
+			}
+			else			
+			{
+				$array[] = array('url'=> e107::url('vstore','dashboard', array('dash' => 'dashboard')), 'text'=> "My Dashboard");
+			}
 		}
 
 


### PR DESCRIPTION
## Customer dashboard #77 

Implemented the remaining pages on the customer dashboard.
Customer can now:
- List all his/her orders
- View details of his/her orders
- Cancel orders, as long as these orders are in state New, Processing and On Hold. Any refunds must be done manually.
- Any cancellations are logged to the order and an email is sent out to the customer (and the shop owner) (if enabled in shop preferences) to inform about the changes.
- View and download all purchased files.
- View and update his addresses (billing and shipping).
- Update his/her account (he/she will moved to this profile page).