### PR TITLE
fixes #148: Clear cart didn't work when not in the shop.

### DIFF
--- a/e_header.php
+++ b/e_header.php
@@ -10,8 +10,36 @@
 
  if(e107::isInstalled('vstore'))
  {
-
-
+    if(deftrue('USER_AREA')) {
+        // prevents inclusion of JS/CSS/meta in the admin area.
+        e107::js('vstore', 'js/vstore.js');
+        e107::lan('vstore', false, true); // e107_plugins/vstore/languages/English_front.php
+        
+        $vstore_prefs = e107::pref('vstore');
+        
+        e107::js('settings', array('vstore' => array(
+                'url' => e107::url('vstore', 'index'),
+                'cart' =>  array(
+                    'url' => e107::url('vstore', 'cart'),
+                    'addtocart' => LAN_VSTORE_001, // 'Add to cart',
+                    'outofstock' => empty($vstore_prefs['caption_outofstock'][e_LANGUAGE])
+                        ? 'Out of stock'
+                        : $vstore_prefs['caption_outofstock'][e_LANGUAGE],
+                    'available' => 'In stock',
+                ),
+                'ImageZoom' => array('url'=>'')
+            )
+        ));
+        
+        
+        if (!empty($vstore_prefs['custom_css']))
+        {
+            // Add any custom css to the page
+            e107::css('inline', "
+            /* vstore custom css */
+            " . $vstore_prefs['custom_css']);
+        }
+    }
 
     class vstore_cart_icon
     {

--- a/vstore.php
+++ b/vstore.php
@@ -6,33 +6,36 @@ if (!defined('e107_INIT'))
 }
 
 e107::js('vstore', 'js/jquery.zoom.min.js');
-e107::js('vstore', 'js/vstore.js');
-e107::lan('vstore', false, true); // e107_plugins/vstore/languages/English_front.php
 
-$vstore_prefs = e107::pref('vstore');
+/// Moved to e_header.php issue #146 ///
+// e107::js('vstore', 'js/vstore.js');
+// e107::lan('vstore', false, true); // e107_plugins/vstore/languages/English_front.php
 
-e107::js('settings', array('vstore' => array(
-        'url' => e107::url('vstore', 'index'),
-		'cart' =>  array(
-			'url' => e107::url('vstore', 'cart'),
-			'addtocart' => LAN_VSTORE_001, // 'Add to cart',
-			'outofstock' => empty($vstore_prefs['caption_outofstock'][e_LANGUAGE])
-				? 'Out of stock'
-				: $vstore_prefs['caption_outofstock'][e_LANGUAGE],
-			'available' => 'In stock',
-		),
-		'ImageZoom' => array('url'=>'')
-	)
-));
+// $vstore_prefs = e107::pref('vstore');
+
+// e107::js('settings', array('vstore' => array(
+//         'url' => e107::url('vstore', 'index'),
+// 		'cart' =>  array(
+// 			'url' => e107::url('vstore', 'cart'),
+// 			'addtocart' => LAN_VSTORE_001, // 'Add to cart',
+// 			'outofstock' => empty($vstore_prefs['caption_outofstock'][e_LANGUAGE])
+// 				? 'Out of stock'
+// 				: $vstore_prefs['caption_outofstock'][e_LANGUAGE],
+// 			'available' => 'In stock',
+// 		),
+// 		'ImageZoom' => array('url'=>'')
+// 	)
+// ));
 
 
-if (!empty($vstore_prefs['custom_css']))
-{
-	// Add any custom css to the page
-	e107::css('inline', "
-	/* vstore custom css */
-	" . $vstore_prefs['custom_css']);
-}
+// if (!empty($vstore_prefs['custom_css']))
+// {
+// 	// Add any custom css to the page
+// 	e107::css('inline', "
+// 	/* vstore custom css */
+// 	" . $vstore_prefs['custom_css']);
+// }
+
 
 $vstore = e107::getSingleton('vstore', e_PLUGIN.'vstore/vstore.class.php');
 $vstore->init();

--- a/vstore_menu.php
+++ b/vstore_menu.php
@@ -18,34 +18,36 @@ if (!defined('e107_INIT')) {
 require_once(e_PLUGIN . 'vstore/vstore.class.php');
 $vst = new vstore;
 
+/// Moved to e_header.php issue #146 ///
 // Loads e_PLUGIN."vstore/languages/English/English_front.php (if English is the current language)
-e107::lan('vstore', false, true);
+// e107::lan('vstore', false, true);
 
-e107::js('vstore', 'js/vstore.js');
+// e107::js('vstore', 'js/vstore.js');
 
-$vstore_prefs = e107::pref('vstore');
+// $vstore_prefs = e107::pref('vstore');
 
-e107::js('settings', array(
-    'vstore' => array(
-        'url' => e107::url('vstore', 'index'),
-        'cart' =>  array(
-            'url' => e107::url('vstore', 'cart'),
-            'addtocart' => 'Add to cart',
-            'outofstock' => empty($vstore_prefs['caption_outofstock'][e_LANGUAGE])
-                ? 'Out of stock'
-                : $vstore_prefs['caption_outofstock'][e_LANGUAGE],
-            'available' => 'In stock',
-        ),
-        'ImageZoom' => array('url' => '')
-    )
-));
+// e107::js('settings', array(
+//     'vstore' => array(
+//         'url' => e107::url('vstore', 'index'),
+//         'cart' =>  array(
+//             'url' => e107::url('vstore', 'cart'),
+//             'addtocart' => 'Add to cart',
+//             'outofstock' => empty($vstore_prefs['caption_outofstock'][e_LANGUAGE])
+//                 ? 'Out of stock'
+//                 : $vstore_prefs['caption_outofstock'][e_LANGUAGE],
+//             'available' => 'In stock',
+//         ),
+//         'ImageZoom' => array('url' => '')
+//     )
+// ));
 
-if (!empty($vstore_prefs['custom_css'])) {
-    // Add any custom css to the page
-    e107::css('inline', "
-    /* vstore custom css */
-    " . $vstore_prefs['custom_css']);
-}
+// if (!empty($vstore_prefs['custom_css'])) {
+//     // Add any custom css to the page
+//     e107::css('inline', "
+//     /* vstore custom css */
+//     " . $vstore_prefs['custom_css']);
+// }
+
 
 $category = vartrue($vstore_prefs['menu_cat'], 1);
 $num_items = vartrue($vstore_prefs['menu_item_count'], 2);


### PR DESCRIPTION
When not in the shop (or when the vstore menu wasn't displayed) the required js wasn't loaded which made clearing the cart fail.
Moved the vstore required js and css to e_header.php